### PR TITLE
Fix race conditions when contexts share an engine

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonBinaryClinicBuiltinNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonBinaryClinicBuiltinNode.java
@@ -68,15 +68,18 @@ public abstract class PythonBinaryClinicBuiltinNode extends PythonBinaryBuiltinN
     }
 
     protected Object castWithNode(ArgumentClinicProvider clinic, VirtualFrame frame, int argIndex, Object value) {
+        ArgumentCastNode castNode;
         if (castNodes == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             castNodes = new ArgumentCastNode[2];
         }
-        if (castNodes[argIndex] == null) {
+        castNode = castNodes[argIndex];
+        if (castNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            castNodes[argIndex] = insert(clinic.createCastNode(argIndex, this));
+            castNode = insert(clinic.createCastNode(argIndex, this));
+            castNodes[argIndex] = castNode;
         }
-        return castNodes[argIndex].execute(frame, value);
+        return castNode.execute(frame, value);
     }
 
     @Override

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonQuaternaryClinicBuiltinNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonQuaternaryClinicBuiltinNode.java
@@ -66,15 +66,18 @@ public abstract class PythonQuaternaryClinicBuiltinNode extends PythonQuaternary
     }
 
     protected Object castWithNode(ArgumentClinicProvider clinic, VirtualFrame frame, int argIndex, Object value) {
+        ArgumentCastNode castNode;
         if (castNodes == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             castNodes = new ArgumentCastNode[4];
         }
-        if (castNodes[argIndex] == null) {
+        castNode = castNodes[argIndex];
+        if (castNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            castNodes[argIndex] = insert(clinic.createCastNode(argIndex, this));
+            castNode = insert(clinic.createCastNode(argIndex, this));
+            castNodes[argIndex] = castNode;
         }
-        return castNodes[argIndex].execute(frame, value);
+        return castNode.execute(frame, value);
     }
 
     @Override

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonTernaryClinicBuiltinNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/function/builtins/PythonTernaryClinicBuiltinNode.java
@@ -66,15 +66,18 @@ public abstract class PythonTernaryClinicBuiltinNode extends PythonTernaryBuilti
     }
 
     protected Object castWithNode(ArgumentClinicProvider clinic, VirtualFrame frame, int argIndex, Object value) {
+        ArgumentCastNode castNode;
         if (castNodes == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             castNodes = new ArgumentCastNode[3];
         }
-        if (castNodes[argIndex] == null) {
+        castNode = castNodes[argIndex];
+        if (castNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-            castNodes[argIndex] = insert(clinic.createCastNode(argIndex, this));
+            castNode = insert(clinic.createCastNode(argIndex, this));
+            castNodes[argIndex] = castNode;
         }
-        return castNodes[argIndex].execute(frame, value);
+        return castNode.execute(frame, value);
     }
 
     @Override


### PR DESCRIPTION
This patch includes fixes for two race conditions when concurrently
running code in two or more contexts that share an engine. 

1. When initializing the SysConfigModuleBuiltins, two threads could
   modify the STATIC_CONFIG_OPTIONS map. This can put the map in an
   inconsistent state. (For instance, it can have one entry but a
   totalCount > 1). Instantiating the map in the initialize method and
   then assigning it to the static value ensures only one thread ever
   touched the map and so it has a consistent state.

2. The PythonNAryClinicBuiltinNodes can have multiple threads call
   castWithNode concurrently on the same object. After one thread has
   assigned a particular castNode, another can overwrite the array with
   an empty one, causing an NPE when re-reading it from the array.
   Instead, the methods can assign directly a local variable and then
   save the values in the array. With this change, a thread doesn't risk
   reading a null after having computed the value.

<details>
<summary>
I found these issues by running this test case:
</summary>
```java
@Test
public void testPythonMultithreaded() throws InterruptedException {
  Source code = Source.create("python", "lambda: 1");
  Engine engine = Engine.create();
  List<Thread> threads = new ArrayList<>();
  for (int i = 0; i < 10; i++) {
    Context context = Context.newBuilder().engine(engine).build();
    Runnable r =
        () -> {
          try (context) {
            context.eval(code).execute();
          }
        };
    threads.add(new Thread(r));
  }
  AtomicBoolean failure = new AtomicBoolean(false);
  for (Thread thread : threads) {
    thread.setUncaughtExceptionHandler(
        (t, e) -> {
          logger.error("Exception thrown by thread", e);
          failure.set(true);
        });
    thread.start();
  }
  for (Thread thread : threads) {
    thread.join();
  }
  assertThat(failure.get()).named("failure").isFalse();
}
```
</details>

Note: The PythonNAryClinicBuiltinNodes still have some much-subtler race
that can manifest in an NPE. I don't understand this code well
generally, including whether we would expect multiple threads to operate
on one of these objects. The root problem may exist on a higher-level than
where I've looked.

----

Second commit

In testing the simple multithreaded test-case I ran into a much rarer
and harder-to-diagnose problem. One thread did not finish executing and
the test hung while consuming large amounts of CPU for a long time.

<details>
<summary>
I took a heap-dump and found the thread stuck in a WeakHashMap
operation
</summary>

```
at java.util.WeakHashMap.expungeStaleEntries()V (WeakHashMap.java:326)
at java.util.WeakHashMap.getTable()[Ljava/util/WeakHashMap$Entry; (WeakHashMap.java:350)
at java.util.WeakHashMap.get(Ljava/lang/Object;)Ljava/lang/Object; (WeakHashMap.java:398)
at com.oracle.graal.python.builtins.modules.PythonCextBuiltins$MakeMayRaiseWrapperNode.make(Lcom/oracle/graal/python/builtins/objects/function/PFunction;Ljava/lang/Object;)Ljava/lang/Object; (PythonCextBuiltins.java:2432)
at com.oracle.graal.python.builtins.modules.PythonCextBuiltinsFactory$MakeMayRaiseWrapperNodeFactory$MakeMayRaiseWrapperNodeGen.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;)Ljava/lang/Object; (PythonCextBuiltinsFactory.java:10424)
at com.oracle.graal.python.nodes.function.builtins.BuiltinCallNode$BuiltinAnyCallNode.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;)Ljava/lang/Object; (BuiltinCallNode.java:64)
at com.oracle.graal.python.nodes.function.BuiltinFunctionRootNode.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;)Ljava/lang/Object; (BuiltinFunctionRootNode.java:331)
at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.executeRootNode(Lcom/oracle/truffle/api/frame/VirtualFrame;)Ljava/lang/Object; (OptimizedCallTarget.java:591)
at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.profiledPERoot([Ljava/lang/Object;)Ljava/lang/Object; (OptimizedCallTarget.java:562)
at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary([Ljava/lang/Object;)Ljava/lang/Object; (OptimizedCallTarget.java:512)
at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke([Ljava/lang/Object;)Ljava/lang/Object; (OptimizedCallTarget.java:496)
at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(Lcom/oracle/truffle/api/nodes/Node;[Ljava/lang/Object;)Ljava/lang/Object; (OptimizedCallTarget.java:459)
at org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call([Ljava/lang/Object;)Ljava/lang/Object; (OptimizedDirectCallNode.java:71)
at com.oracle.graal.python.nodes.call.CallTargetInvokeNode.doNoClosure(Lcom/oracle/truffle/api/frame/VirtualFrame;Lcom/oracle/graal/python/builtins/objects/function/PFunction;Lcom/oracle/graal/python/builtins/objects/object/PythonObject;[Lcom/oracle/graal/python/builtins/objects/cell/PCell;[Ljava/lang/Object;Lcom/oracle/truffle/api/profiles/ConditionProfile;Lcom/oracle/truffle/api/profiles/ConditionProfile;Lcom/oracle/graal/python/runtime/PythonContext;)Ljava/lang/Object; (CallTargetInvokeNode.java:128)
at com.oracle.graal.python.nodes.call.CallTargetInvokeNodeGen.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;Lcom/oracle/graal/python/builtins/objects/function/PFunction;Lcom/oracle/graal/python/builtins/objects/object/PythonObject;[Lcom/oracle/graal/python/builtins/objects/cell/PCell;[Ljava/lang/Object;)Ljava/lang/Object; (CallTargetInvokeNodeGen.java:42)
at com.oracle.graal.python.nodes.call.CallDispatchNode.callBuiltinFunctionCachedCt(Lcom/oracle/truffle/api/frame/VirtualFrame;Lcom/oracle/graal/python/builtins/objects/function/PBuiltinFunction;[Ljava/lang/Object;Lcom/oracle/truffle/api/RootCallTarget;Lcom/oracle/graal/python/nodes/call/CallTargetInvokeNode;)Ljava/lang/Object; (CallDispatchNode.java:132)
at com.oracle.graal.python.nodes.call.CallDispatchNodeGen.executeInternal(Lcom/oracle/truffle/api/frame/Frame;Lcom/oracle/graal/python/builtins/objects/function/PBuiltinFunction;[Ljava/lang/Object;)Ljava/lang/Object; (CallDispatchNodeGen.java:65)
at com.oracle.graal.python.nodes.call.CallDispatchNode.executeCall(Lcom/oracle/truffle/api/frame/VirtualFrame;Lcom/oracle/graal/python/builtins/objects/function/PBuiltinFunction;[Ljava/lang/Object;)Ljava/lang/Object; (CallDispatchNode.java:83)
at com.oracle.graal.python.nodes.call.CallNode.builtinMethodCallBuiltinDirect(Lcom/oracle/truffle/api/frame/VirtualFrame;Lcom/oracle/graal/python/builtins/objects/method/PBuiltinMethod;[Ljava/lang/Object;[Lcom/oracle/graal/python/builtins/objects/function/PKeyword;Lcom/oracle/graal/python/nodes/call/CallDispatchNode;Lcom/oracle/graal/python/nodes/argument/CreateArgumentsNode;)Ljava/lang/Object; (CallNode.java:161)
at com.oracle.graal.python.nodes.call.CallNodeGen.executeInternal(Lcom/oracle/truffle/api/frame/Frame;Ljava/lang/Object;[Ljava/lang/Object;[Lcom/oracle/graal/python/builtins/objects/function/PKeyword;)Ljava/lang/Object; (CallNodeGen.java:95)
at com.oracle.graal.python.nodes.call.CallNode.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;Ljava/lang/Object;[Ljava/lang/Object;[Lcom/oracle/graal/python/builtins/objects/function/PKeyword;)Ljava/lang/Object; (CallNode.java:107)
at com.oracle.graal.python.nodes.call.special.CallBinaryMethodNode.call(Lcom/oracle/truffle/api/frame/VirtualFrame;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lcom/oracle/graal/python/nodes/call/CallNode;Lcom/oracle/truffle/api/profiles/ConditionProfile;)Ljava/lang/Object; (CallBinaryMethodNode.java:480)
at com.oracle.graal.python.nodes.call.special.CallBinaryMethodNodeGen.executeObject(Lcom/oracle/truffle/api/frame/Frame;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (CallBinaryMethodNodeGen.java:1076)
at com.oracle.graal.python.nodes.call.PythonCallNode$PythonCallBinary.execute(Lcom/oracle/truffle/api/frame/VirtualFrame;)Ljava/lang/Object; (PythonCallNode.java:202)
at com.oracle.graal.python.nodes.frame.WriteLocalVariableNodeGen.executeVoid_generic4(ILcom/oracle/truffle/api/frame/VirtualFrame;)V (WriteLocalVariableNodeGen.java:115)
```
</details>

PythonCextBuiltins.MakeMayRaiseWrapperNode does unsynchronized modify
operations to a WeakHashMap. Because the WeakHashMap is not
synchronized, this risks putting it in an inconsistent state. Here, it
likely created a loop in the linked list of nodes, causing an iteration
over the elements to never finish.

While I haven't proven this to be the root cause, analyzing the heap dump did
show a self-reference in a WeakHashMap.Entry object referenced by both the
map and the stuck stack frame. This seems reasonably conclusive, unless the
WeakHashMap does something subtler than I understand.

<img width="1341" alt="Screen Shot 2021-02-23 at 12 40 15 PM" src="https://user-images.githubusercontent.com/7101542/108905581-bb404500-75d4-11eb-8627-61f3e9d0be29.png">

Probably there exists a better solution than wrapping the WeakHashMap in a
synchronized map, but I don't know it.