### PR TITLE
Adding hasTag method to write local variable node class, and python call nodes taking one to four arguments.

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/frame/WriteLocalVariableNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/frame/WriteLocalVariableNode.java
@@ -31,6 +31,8 @@ import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.NodeInfo;
 
 @NodeInfo(shortName = "write_local")
@@ -89,5 +91,10 @@ public abstract class WriteLocalVariableNode extends StatementNode implements Wr
     void writeObject(VirtualFrame frame, Object value) {
         FrameSlotGuards.ensureObjectKind(frame, frameSlot);
         frame.setObject(frameSlot, value);
+    }
+
+    @Override
+    public boolean hasTag(Class<? extends Tag> tag) {
+        return StandardTags.WriteVariableTag.class == tag || super.hasTag(tag);
     }
 }


### PR DESCRIPTION
The `com.oracle.graal.python.nodes.frame.WriteLocalVariableNode` class does not override the `hasTag` method which provides the corresponding instrumentation tags. Same issue with the four nested classes: `PythonCallUnary`, `PythonCallBinary`, `PythonCallTernary` and `PythonCallQuaternary` of the `com.oracle.graal.python.nodes.call.PythonCallNode` class.

The corresponding issue is: https://github.com/oracle/graalpython/issues/280

The proposed fixes in this PR override the `hasTag` method in those classes. 