### PR TITLE
Improve foreign list concat and repeat

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
@@ -358,10 +358,7 @@ public class ForeignObjectBuiltins extends PythonBuiltins {
                 Object[] unpackedRight = unpackForeignArray(right, lib, convert);
                 if (unpackedLeft != null && unpackedRight != null) {
                     Object[] result = Arrays.copyOf(unpackedLeft, unpackedLeft.length + unpackedRight.length);
-                    for (int i = 0, j = unpackedLeft.length; i < unpackedRight.length && j < result.length; i++, j++) {
-                        assert j < result.length;
-                        result[j] = unpackedRight[i];
-                    }
+                    System.arraycopy(unpackedRight, 0, result, unpackedLeft.length, unpackedRight.length);
                     return factory.createList(result);
                 }
             } finally {
@@ -438,11 +435,10 @@ public class ForeignObjectBuiltins extends PythonBuiltins {
                     if (rightInt < 0) {
                         return factory.createList();
                     }
-                    Object[] repeatedData = new Object[Math.max(0, Math.multiplyExact(unpackForeignArray.length, rightInt > 0 ? rightInt : 0))];
+                    Object[] repeatedData = new Object[Math.multiplyExact(unpackForeignArray.length, rightInt)];
 
-                    // repeat data
-                    for (int i = 0; i < repeatedData.length; i++) {
-                        repeatedData[i] = unpackForeignArray[i % unpackForeignArray.length];
+                    for (int i = 0; i < rightInt; i++) {
+                        System.arraycopy(unpackForeignArray, 0, repeatedData, i * unpackForeignArray.length, unpackForeignArray.length);
                     }
 
                     return factory.createList(repeatedData);


### PR DESCRIPTION
This PR improves the performance of `__ADD__` (~ -15%) and `__MUL__` (~ -50%) of foreign lists. 

```
22.3.0
Graal.testConcatLoop  avgt   10   100739481.257 ±   6567162.023  ns/op
Graal.testRepeatLoop  avgt   10  3687803989.367 ± 126218185.679  ns/op

22.3.0 + patch
Graal.testConcatLoop  avgt   10    86915832.507 ±   5023502.266  ns/op
Graal.testRepeatLoop  avgt   10  1812578621.783 ± 121703465.844  ns/op
```