### PR TITLE
remove usage of os.O_NOCTTY in getpass module

### DIFF
--- a/graalpython/lib-python/3/getpass.py
+++ b/graalpython/lib-python/3/getpass.py
@@ -45,7 +45,7 @@ def unix_getpass(prompt='Password: ', stream=None):
     with contextlib.ExitStack() as stack:
         try:
             # Always try reading and writing directly on the tty first.
-            fd = os.open('/dev/tty', os.O_RDWR|os.O_NOCTTY)
+            fd = os.open('/dev/tty', os.O_RDWR)
             tty = io.FileIO(fd, 'w+')
             stack.enter_context(tty)
             input = io.TextIOWrapper(tty)

--- a/graalpython/lib-python/3/test/test_getpass.py
+++ b/graalpython/lib-python/3/test/test_getpass.py
@@ -103,8 +103,7 @@ class UnixGetpassTest(unittest.TestCase):
             # fully if an alternate implementation works differently.
             open.return_value = None
             getpass.unix_getpass()
-            open.assert_called_once_with('/dev/tty',
-                                         os.O_RDWR | os.O_NOCTTY)
+            open.assert_called_once_with('/dev/tty', os.O_RDWR)
             fileio.assert_called_once_with(open.return_value, 'w+')
             textio.assert_called_once_with(fileio.return_value)
 


### PR DESCRIPTION
`os.O_NOCTTY` is not implemented (yet?), and it doesn't seem to make a difference in `getpass()` usage anyway.

## O_NOCTTY docs

```

       O_NOCTTY
              If pathname refers to a terminal device—see tty(4)—it will
              not become the process's controlling terminal even if the
              process does not have one.
```

https://man7.org/linux/man-pages/man2/openat.2.html