### PR TITLE
Added patch for charset-normalizer == 3.1.0

### DIFF
--- a/graalpython/lib-graalpython/patches/charset_normalizer/whl/charset_normalizer-3.1.0.patch
+++ b/graalpython/lib-graalpython/patches/charset_normalizer/whl/charset_normalizer-3.1.0.patch
@@ -1,0 +1,27 @@
+diff --git a/charset_normalizer/utils.py b/charset_normalizer/utils.py
+index dcb14df..12079e3 100644
+--- a/charset_normalizer/utils.py
++++ b/charset_normalizer/utils.py
+@@ -11,7 +11,10 @@ from functools import lru_cache
+ from re import findall
+ from typing import List, Optional, Set, Tuple, Union
+ 
+-from _multibytecodec import MultibyteIncrementalDecoder
++try:
++    from _multibytecodec import MultibyteIncrementalDecoder
++except ImportError:
++    MultibyteIncrementalDecoder = None
+ 
+ from .constant import (
+     ENCODING_MARKS,
+@@ -244,7 +247,7 @@ def is_multi_byte_encoding(name: str) -> bool:
+     } or issubclass(
+         importlib.import_module("encodings.{}".format(name)).IncrementalDecoder,  # type: ignore
+         MultibyteIncrementalDecoder,
+-    )
++    ) if MultibyteIncrementalDecoder else False
+ 
+ 
+ def identify_sig_or_bom(sequence: bytes) -> Tuple[Optional[str], bytes]:
+-- 
+3.1.0


### PR DESCRIPTION
`utils.py` has changed slightly:

https://github.com/Ousret/charset_normalizer/blob/3.1.0/charset_normalizer/utils.py

```
Collecting charset-normalizer<4.0,>=2.0
  Downloading charset_normalizer-3.1.0-py3-none-any.whl (46 kB)
     |████████████████████████████████| 46 kB 631 kB/s
Looking for GraalPy patches for charset_normalizer
Patching package charset_normalizer using /Library/Java/JavaVirtualMachines/graalvm-ce-java19-22.3.1/Contents/Home/languages/python/lib-graalpython/patches/charset_normalizer/whl/charset_normalizer.patch
patching file charset_normalizer/utils.py
Hunk #1 FAILED at 11.
Hunk #2 succeeded at 258 with fuzz 2 (offset 11 lines).
1 out of 2 hunks FAILED -- saving rejects to file charset_normalizer/utils.py.rej
```