### PR TITLE
BigInteger support in PInt

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/com/oracle/graal/python/test/interop/JavaInteropTest.java
+++ b/graalpython/com.oracle.graal.python.test/src/com/oracle/graal/python/test/interop/JavaInteropTest.java
@@ -82,6 +82,7 @@ import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.strings.TruffleString;
+import java.math.BigInteger;
 
 @RunWith(Enclosed.class)
 public class JavaInteropTest {
@@ -212,6 +213,19 @@ public class JavaInteropTest {
             Value main = context.getPolyglotBindings().getMember("foo");
             main.execute((float) 1.0, (float) 2.0);
             assertEquals("2.0\n", out.toString("UTF-8"));
+        }
+
+        @Test
+        public void testPassingBigIntegers() throws UnsupportedEncodingException {
+            String source = "import polyglot\n" +
+                            "@polyglot.export_value\n" +
+                            "def foo(x, y):\n" +
+                            "    print(int(x) + int(y))\n\n";
+            Source script = Source.create("python", source);
+            context.eval(script);
+            Value main = context.getPolyglotBindings().getMember("foo");
+            main.execute(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO), BigInteger.valueOf(7));
+            assertEquals("18446744073709551621\n", out.toString("UTF-8"));
         }
 
         @Test

--- a/graalpython/com.oracle.graal.python.test/src/com/oracle/graal/python/test/interop/JavaInteropTest.java
+++ b/graalpython/com.oracle.graal.python.test/src/com/oracle/graal/python/test/interop/JavaInteropTest.java
@@ -220,12 +220,21 @@ public class JavaInteropTest {
             String source = "import polyglot\n" +
                             "@polyglot.export_value\n" +
                             "def foo(x, y):\n" +
-                            "    print(int(x) + int(y))\n\n";
+                            "    print(int(x) * int(y))\n\n";
             Source script = Source.create("python", source);
             context.eval(script);
             Value main = context.getPolyglotBindings().getMember("foo");
             main.execute(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TWO), BigInteger.valueOf(7));
-            assertEquals("18446744073709551621\n", out.toString("UTF-8"));
+            assertEquals("129127208515966861298\n", out.toString("UTF-8"));
+            out.reset();
+            main.execute(Long.MAX_VALUE, 14);
+            assertEquals("129127208515966861298\n", out.toString("UTF-8"));
+            out.reset();
+            main.execute(6, 7);
+            assertEquals("42\n", out.toString("UTF-8"));
+            out.reset();
+            main.execute(true, true);
+            assertEquals("1\n", out.toString("UTF-8"));
         }
 
         @Test

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
@@ -1045,7 +1045,7 @@ public final class ForeignObjectBuiltins extends PythonBuiltins {
                         return factory.createInt(big);
                     } catch (UnsupportedMessageException e) {
                         CompilerDirectives.transferToInterpreterAndInvalidate();
-                        throw new IllegalStateException("foreign value claims to be a boolean but isn't");
+                        throw new IllegalStateException("foreign value claims to be a big integer but isn't");
                     }
                 }
                 throw raiseNode.raiseIntegerInterpretationError(object);

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/ForeignObjectBuiltins.java
@@ -995,11 +995,12 @@ public final class ForeignObjectBuiltins extends PythonBuiltins {
     @Builtin(name = J___INDEX__, minNumOfPositionalArgs = 1)
     @GenerateNodeFactory
     abstract static class IndexNode extends PythonUnaryBuiltinNode {
-        @Specialization(limit = "3", guards="lib.fitsInLong(object)")
-        protected static long doIt(Object object,
+        @Specialization(limit = "3")
+        protected static Object doIt(Object object,
                         @Cached PRaiseNode raiseNode,
                         @CachedLibrary("object") InteropLibrary lib,
-                        @Cached GilNode gil) {
+                        @Cached GilNode gil,
+                        @Cached PythonObjectFactory factory) {
             gil.release(true);
             try {
                 if (lib.isBoolean(object)) {
@@ -1026,19 +1027,6 @@ public final class ForeignObjectBuiltins extends PythonBuiltins {
                         throw new IllegalStateException("foreign value claims it fits into index-sized long, but doesn't");
                     }
                 }
-                throw raiseNode.raiseIntegerInterpretationError(object);
-            } finally {
-                gil.acquire();
-            }
-        }
-        @Specialization(limit = "3", guards="lib.fitsInBigInteger(object)")
-        protected static PInt doBigInteger(Object object,
-                        @Cached PRaiseNode raiseNode,
-                        @CachedLibrary("object") InteropLibrary lib,
-                        @Cached GilNode gil,
-                        @Cached PythonObjectFactory factory) {
-            gil.release(true);
-            try {
                 if (lib.fitsInBigInteger(object)) {
                     try {
                         var big = lib.asBigInteger(object);

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/ints/PInt.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/ints/PInt.java
@@ -301,6 +301,16 @@ public final class PInt extends PythonBuiltinObject {
         }
     }
 
+    @ExportMessage
+    boolean fitsInBigInteger() {
+      return true;
+    }
+
+    @ExportMessage
+    BigInteger asBigInteger() {
+      return value;
+    }
+
     @Override
     public int hashCode() {
         return value.hashCode();


### PR DESCRIPTION
Expose big integers by reacting to `asBigInteger` message in `PInt`. Making sure big integer can be passed into Python.