### PR TITLE
Don't ignore days in timedelta when converting to TimeZone

### DIFF
--- a/graalpython/com.oracle.graal.python.test.integration/src/com/oracle/graal/python/test/integration/interop/TimeDateTest.java
+++ b/graalpython/com.oracle.graal.python.test.integration/src/com/oracle/graal/python/test/integration/interop/TimeDateTest.java
@@ -42,6 +42,8 @@ package com.oracle.graal.python.test.integration.interop;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.time.LocalDate;
@@ -164,6 +166,22 @@ public class TimeDateTest extends PythonTests {
         checkDate(value, 2011, 11, 4);
         checkTime(value, 0, 5, 23, 283000000);
         assertEquals(ZoneId.of("UTC+4"), value.asTimeZone());
+    }
+
+    @Test
+    public void testDateTimeDateTime04() {
+        String source = "from datetime import timedelta, datetime, timezone\n" +
+                        "\n" +
+                        "zone = timezone(timedelta(seconds=-18000), \"US/Eastern\")\n" +
+                        "dt = datetime(1970, 1, 1, 0, 0, 1, tzinfo=zone)\n" +
+                        "\n" +
+                        "\n" +
+                        "dt";
+        Value value = getValue(source, ZoneId.of("US/Eastern"));
+        assertTrue("Value represents a datatime: " + value, value.isDate());
+        assertTrue("Value represents a datatime: " + value, value.isTime());
+        assertTrue("Value represents a timezone: " + value, value.isTimeZone());
+        assertNotNull("Can return a time zone", value.asTimeZone());
     }
 
     @Test

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/PythonAbstractObject.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/PythonAbstractObject.java
@@ -993,7 +993,9 @@ public abstract class PythonAbstractObject extends DynamicObject implements Truf
                             Object delta = lib.invokeMember(tzinfo, "utcoffset", new Object[]{this});
                             if (delta != PNone.NONE) {
                                 int seconds = castToIntNode.execute(inliningTarget, lib.readMember(delta, "seconds"));
-                                return createZoneId(seconds);
+                                int days = castToIntNode.execute(inliningTarget, lib.readMember(delta, "days"));
+                                int offset = days * 3600 * 24 + seconds;
+                                return createZoneId(offset);
                             }
                         }
                     } catch (UnsupportedMessageException | UnknownIdentifierException | ArityException | UnsupportedTypeException ex) {


### PR DESCRIPTION
Trying to create a date in `US/New_York` timezone and convert it into Java fails. This was reported to Enso by our US based developer: https://github.com/enso-org/enso/issues/7655 - the final exception is:
```
Execution finished with an error: java.time.DateTimeException: Zone offset not in valid range: -18:00 to +18:00
        at <java> java.base/java.time.ZoneOffset.ofTotalSeconds(ZoneOffset.java:417)
        at <java> com.oracle.graal.python.builtins.objects.PythonAbstractObject.createZoneId(PythonAbstractObject.java:1001)
        at <java> com.oracle.graal.python.builtins.objects.PythonAbstractObject.asTimeZone(PythonAbstractObject.java:949)
```
I have investigated the issue and I am providing a test to simulate the problem as well as a possible fix. the issue is that running:
```python
from datetime import timedelta, datetime, timezone

zone = timezone(timedelta(seconds=-18000), "US/Eastern")
dt = datetime(1970, 1, 1, 0, 0, 1, tzinfo=zone)


print(dt)
print(dt.tzinfo)
print(dt.tzinfo.utcoffset(dt).seconds)

dt.tzinfo
```
yields
```
1970-01-01 00:00:01-05:00
US/Eastern
68400
```
e.g. the value of seconds field is bigger than allowed -18:00 and +18:00. My fix also reads value of `days` which is (in this case) `-1` and compensates the value to fit into the desired range.