### PR TITLE
Adds a gradle plugin for graalpy

### DIFF
--- a/graalpython/graalpy-gradle-plugin/pom.xml
+++ b/graalpython/graalpy-gradle-plugin/pom.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or
+data (collectively the "Software"), free of charge and under any and all
+copyright rights in the Software, and any and all patent rights owned or
+freely licensable by each licensor hereunder covering either (i) the
+unmodified Software as contributed to or provided by such licensor, or (ii)
+the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a
+minimum a reference to the UPL must be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.python</groupId>
+    <artifactId>graalpy-gradle-plugin</artifactId>
+    <packaging>jar</packaging>
+    <!-- This version is always overridden when deploying using mx -->
+    <version>24.2.0</version>
+    <url>http://www.graalvm.org/</url>
+    <name>graalpy-gradle-plugin</name>
+    <description>Handles python related resources in a gradle GraalPy - Java application.</description>
+
+    <properties>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <graalpy.version>24.2.0</graalpy.version>
+        <gradle.version>6.1.1</gradle.version>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>Version from suite</id>
+            <activation>
+                <property>
+                    <name>env.GRAALPY_VERSION</name>
+                </property>
+            </activation>
+            <properties>
+                <graalpy.version>${env.GRAALPY_VERSION}</graalpy.version>
+            </properties>
+        </profile>
+    </profiles>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.22</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core-api</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-model-core</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-java</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-jvm</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-platform-jvm</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services</artifactId>
+            <version>${gradle.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-plugins</artifactId>
+            <scope>provided</scope>
+            <version>${gradle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-logging</artifactId>
+            <version>${gradle.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-embedding-tools</artifactId>
+            <version>${graalpy.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-launcher</artifactId>
+            <version>${graalpy.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>maven</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+            <id>gradle</id>
+            <url>https://repo.gradle.org/gradle/libs-releases/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>gradle-local</id>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+
+</project>

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python;
 
 import org.graalvm.python.dsl.GraalPyExtension;

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
@@ -1,0 +1,103 @@
+package org.graalvm.python;
+
+import org.graalvm.python.dsl.GraalPyExtension;
+import org.graalvm.python.tasks.GenerateManifestTask;
+import org.graalvm.python.tasks.InstallPackagesTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.jvm.tasks.Jar;
+import org.gradle.language.jvm.tasks.ProcessResources;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public abstract class GraalPyGradlePlugin implements Plugin<Project> {
+    private static final String PYTHON_LAUNCHER_ARTIFACT_ID = "python-launcher";
+    private static final String PYTHON_EMBEDDING_ARTIFACT_ID = "python-embedding";
+    public static final String GRAALPY_GROUP_ID = "org.graalvm.python";
+
+    private static final String POLYGLOT_GROUP_ID = "org.graalvm.polyglot";
+    private static final String PYTHON_COMMUNITY_ARTIFACT_ID = "python-community";
+    private static final String PYTHON_ARTIFACT_ID = "python";
+    private static final String GRAALPY_GRADLE_PLUGIN_TASK_GROUP = "graalpy";
+
+    private static final String DEFAULT_WRAPPER_DIRECTORY = "python-generated";
+
+    GraalPyExtension extension;
+    Project project;
+
+    @Override
+    public void apply(Project project) {
+        this.project = project;
+        project.getPluginManager().apply(JavaPlugin.class);
+
+
+        this.extension = project.getExtensions().create("graalPy", GraalPyExtension.class);
+        extension.getPythonHome().getIncludes().convention(List.of(".*"));
+        extension.getPythonHome().getExcludes().convention(Collections.emptyList());
+        extension.getPackages().convention(Collections.emptyList());
+
+        var installPackagesTask = project.getTasks().register("installPackages", InstallPackagesTask.class);
+
+
+        final var generateManifestTask = project.getTasks().register("generateManifest", GenerateManifestTask.class);
+        project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME, t -> ((Jar) t).getMetaInf().from(generateManifestTask));
+        generateManifestTask.configure(t -> {
+            t.getManifestOutputDir().convention(project.getLayout().getBuildDirectory().dir("GRAAL-META-INF"));
+            t.setGroup(GRAALPY_GRADLE_PLUGIN_TASK_GROUP);
+        });
+
+        installPackagesTask.configure(t -> {
+            t.getIncludes().set(extension.getPythonHome().getIncludes());
+            t.getExcludes().set(extension.getPythonHome().getExcludes());
+            t.getPackages().set(extension.getPackages());
+            t.getIncludeVfsRoot().set(extension.getIncludeVfsRootDir());
+
+            t.getOutput().set(extension.getPythonResourcesDirectory());
+
+            t.setGroup(GRAALPY_GRADLE_PLUGIN_TASK_GROUP);
+        });
+
+        project.afterEvaluate(p -> {
+            checkAndAddDependencies();
+
+            if (!extension.getPythonResourcesDirectory().isPresent())
+                ((ProcessResources) project.getTasks().getByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME)).with(project.copySpec().from(installPackagesTask));
+
+            // Provide the default value after the isPresent check, otherwise isPresent always returns true
+            extension.getPythonResourcesDirectory().convention(project.getLayout().getBuildDirectory().dir(DEFAULT_WRAPPER_DIRECTORY));
+        });
+
+    }
+
+
+    private void checkAndAddDependencies() {
+        project.getDependencies().add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, "%s:%s:%s".formatted(GRAALPY_GROUP_ID, PYTHON_LAUNCHER_ARTIFACT_ID, getGraalPyVersion(project)));
+        project.getDependencies().add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, "%s:%s:%s".formatted(GRAALPY_GROUP_ID, PYTHON_EMBEDDING_ARTIFACT_ID, getGraalPyVersion(project)));
+    }
+
+
+    public static String getGraalPyVersion(Project project) {
+        return getGraalPyDependency(project).getVersion();
+    }
+
+    public static Dependency getGraalPyDependency(Project project) {
+        return resolveProjectDependencies(project).stream().filter(GraalPyGradlePlugin::isPythonArtifact).findFirst().orElseThrow(() -> new GradleException("Missing GraalPy dependency. Please add to your build.gradle either %s:%s or %s:%s".formatted(POLYGLOT_GROUP_ID, PYTHON_COMMUNITY_ARTIFACT_ID, POLYGLOT_GROUP_ID, PYTHON_ARTIFACT_ID)));
+    }
+
+    private static boolean isPythonArtifact(Dependency dependency) {
+        return (POLYGLOT_GROUP_ID.equals(dependency.getGroup()) || GRAALPY_GROUP_ID.equals(dependency.getGroup())) &&
+                (PYTHON_COMMUNITY_ARTIFACT_ID.equals(dependency.getName()) || PYTHON_ARTIFACT_ID.equals(dependency.getName()));
+    }
+
+    private static DependencySet resolveProjectDependencies(Project project) {
+        return project.getConfigurations().getByName("implementation").getAllDependencies();
+    }
+
+
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GradleLogger.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GradleLogger.java
@@ -1,0 +1,37 @@
+package org.graalvm.python;
+
+import groovy.util.logging.Log;
+import org.graalvm.python.embedding.tools.exec.SubprocessLog;
+import org.gradle.api.logging.Logger;
+
+public class GradleLogger implements SubprocessLog {
+    private Logger logger;
+
+    private GradleLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void subProcessOut(CharSequence out) {
+        logger.lifecycle(out.toString());
+    }
+
+    @Override
+    public void subProcessErr(CharSequence err) {
+        logger.warn(err.toString());
+    }
+
+    @Override
+    public void log(CharSequence txt) {
+        logger.lifecycle(txt.toString());
+    }
+
+    @Override
+    public void log(CharSequence txt, Throwable t) {
+        logger.lifecycle(txt.toString(), t);
+    }
+
+    public static GradleLogger of(Logger logger) {
+        return new GradleLogger(logger);
+    }
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GradleLogger.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/GradleLogger.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python;
 
 import groovy.util.logging.Log;

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/GraalPyExtension.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/GraalPyExtension.java
@@ -1,0 +1,23 @@
+package org.graalvm.python.dsl;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+
+public interface GraalPyExtension {
+    DirectoryProperty getPythonResourcesDirectory();
+
+    ListProperty<String> getPackages();
+
+    Property<Boolean> getIncludeVfsRootDir();
+
+    @Nested
+    PythonHomeInfo getPythonHome();
+
+    default void pythonHome(Action<? super PythonHomeInfo> action) {
+        action.execute(getPythonHome());
+    }
+
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/GraalPyExtension.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/GraalPyExtension.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python.dsl;
 
 import org.gradle.api.Action;

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/PythonHomeInfo.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/PythonHomeInfo.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python.dsl;
 
 import org.gradle.api.provider.SetProperty;

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/PythonHomeInfo.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/dsl/PythonHomeInfo.java
@@ -1,0 +1,8 @@
+package org.graalvm.python.dsl;
+
+import org.gradle.api.provider.SetProperty;
+
+public interface PythonHomeInfo {
+    SetProperty<String> getIncludes();
+    SetProperty<String> getExcludes();
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/GenerateManifestTask.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/GenerateManifestTask.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python.tasks;
 
 import org.gradle.api.DefaultTask;

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/GenerateManifestTask.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/GenerateManifestTask.java
@@ -1,0 +1,58 @@
+package org.graalvm.python.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleScriptException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.graalvm.python.GraalPyGradlePlugin.GRAALPY_GROUP_ID;
+import static org.graalvm.python.embedding.tools.vfs.VFSUtils.VFS_ROOT;
+
+
+public abstract class GenerateManifestTask extends DefaultTask {
+
+    private static final String NATIVE_IMAGE_RESOURCES_CONFIG = """
+            {
+              "resources": {
+                "includes": [
+                  {"pattern": "$vfs/.*"}
+                ]
+              }
+            }
+            """.replace("$vfs", VFS_ROOT);
+
+    private static final String NATIVE_IMAGE_ARGS = "Args = -H:-CopyLanguageResources";
+    private static final String GRAALPY_GRADLE_PLUGIN_ARTIFACT_ID = "graalpy-gradle-plugin";
+
+    @OutputDirectory
+    public abstract DirectoryProperty getManifestOutputDir();
+
+    @TaskAction
+    public void generateManifest() {
+        Path metaInf = getMetaInfDirectory();
+        Path resourceConfig = metaInf.resolve("resource-config.json");
+        try {
+            Files.createDirectories(resourceConfig.getParent());
+            Files.writeString(resourceConfig, NATIVE_IMAGE_RESOURCES_CONFIG, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new GradleScriptException(String.format("failed to write %s", resourceConfig), e);
+        }
+        Path nativeImageProperties = metaInf.resolve("native-image.properties");
+        try {
+            Files.createDirectories(nativeImageProperties.getParent());
+            Files.writeString(nativeImageProperties, NATIVE_IMAGE_ARGS, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new GradleScriptException(String.format("failed to write %s", nativeImageProperties), e);
+        }
+    }
+
+    private Path getMetaInfDirectory() {
+        return Path.of(getManifestOutputDir().get().getAsFile().getAbsolutePath(), "native-image", GRAALPY_GROUP_ID, GRAALPY_GRADLE_PLUGIN_ARTIFACT_ID);
+    }
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/InstallPackagesTask.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/InstallPackagesTask.java
@@ -1,0 +1,358 @@
+package org.graalvm.python.tasks;
+
+import org.graalvm.python.GradleLogger;
+import org.graalvm.python.embedding.tools.exec.GraalPyRunner;
+import org.graalvm.python.embedding.tools.vfs.VFSUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.GradleScriptException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.*;
+import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.Optional;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.graalvm.python.GraalPyGradlePlugin.getGraalPyDependency;
+import static org.graalvm.python.GraalPyGradlePlugin.getGraalPyVersion;
+import static org.graalvm.python.embedding.tools.vfs.VFSUtils.*;
+
+public abstract class InstallPackagesTask extends DefaultTask {
+    private static final String GRAALPY_GROUP_ID = "org.graalvm.python";
+
+    private static final String GRAALPY_MAIN_CLASS = "com.oracle.graal.python.shell.GraalPythonMain";
+
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    private static final String LAUNCHER = IS_WINDOWS ? "graalpy.exe" : "graalpy.sh";
+
+    private static final String INCLUDE_PREFIX = "include:";
+
+    private static final String EXCLUDE_PREFIX = "exclude:";
+
+    private Set<String> launcherClassPath;
+
+    @Input
+    @Optional
+    public abstract Property<Boolean> getIncludeVfsRoot();
+
+    @Input
+    public abstract ListProperty<String> getPackages();
+
+    @Input
+    public abstract ListProperty<String> getIncludes();
+
+    @Input
+    public abstract ListProperty<String> getExcludes();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutput();
+
+    @TaskAction
+    public void exec() {
+        manageHome();
+        manageVenv();
+        listGraalPyResources();
+    }
+
+    private void manageHome() {
+        Path homeDirectory = getHomeDirectory();
+        Path tagfile = homeDirectory.resolve("tagfile");
+        String graalPyVersion = getGraalPyVersion(getProject());
+
+        List<String> includes = new ArrayList<>(getIncludes().get());
+        List<String> excludes = new ArrayList<>(getExcludes().get());
+
+        trim(includes);
+        trim(excludes);
+
+        if (Files.isReadable(tagfile)) {
+            List<String> lines;
+            try {
+                lines = Files.readAllLines(tagfile);
+            } catch (IOException e) {
+                throw new GradleScriptException(String.format("failed to read tag file %s", tagfile), e);
+            }
+            if (lines.isEmpty() || !graalPyVersion.equals(lines.get(0))) {
+                getLogger().lifecycle(String.format("Stale GraalPy home, updating to %s", graalPyVersion));
+                delete(homeDirectory);
+            }
+            if (pythonHomeChanged(includes, excludes, lines)) {
+                getLogger().lifecycle(String.format("Deleting GraalPy home due to changed includes or excludes"));
+                delete(homeDirectory);
+            }
+        }
+
+        try {
+            if (!Files.exists(homeDirectory)) {
+                getLogger().lifecycle(String.format("Creating GraalPy %s home in %s", graalPyVersion, homeDirectory));
+                Files.createDirectories(homeDirectory.getParent());
+                VFSUtils.copyGraalPyHome(calculateLauncherClasspath(), homeDirectory, includes, excludes, GradleLogger.of(getLogger()));
+            }
+            Files.write(tagfile, List.of(graalPyVersion), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            write(tagfile, includes, INCLUDE_PREFIX);
+            write(tagfile, excludes, EXCLUDE_PREFIX);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleException(String.format("failed to copy graalpy home %s", homeDirectory), e);
+        }
+    }
+
+    private void manageVenv() {
+        generateLaunchers();
+
+        Path venvDirectory = getVenvDirectory();
+
+        Path venvContents = venvDirectory.resolve("contents");
+        List<String> installedPackages = new ArrayList<>();
+        String graalPyVersion = getGraalPyVersion(getProject());
+
+        var packages = getPackages().getOrElse(null);
+
+        if (packages != null && !packages.isEmpty()) {
+            trim(packages);
+        }
+
+        if (packages == null || packages.isEmpty()) {
+            getLogger().lifecycle(String.format("No venv packages declared, deleting %s", venvDirectory));
+            delete(venvDirectory);
+            return;
+        }
+
+        if (Files.isReadable(venvContents)) {
+            List<String> lines = null;
+            try {
+                lines = Files.readAllLines(venvContents);
+            } catch (IOException e) {
+                throw new GradleScriptException(String.format("failed to read tag file %s", venvContents), e);
+            }
+            if (lines.isEmpty() || !graalPyVersion.equals(lines.get(0))) {
+                getLogger().lifecycle(String.format("Stale GraalPy venv, updating to %s", graalPyVersion));
+                delete(venvDirectory);
+            } else {
+                for (int i = 1; i < lines.size(); i++) {
+                    installedPackages.add(lines.get(i));
+                }
+            }
+        } else {
+            getLogger().lifecycle(String.format("Creating GraalPy %s venv", graalPyVersion));
+        }
+
+        if (!Files.exists(venvDirectory)) {
+            runLauncher(getLauncherPath().toString(), "-m", "venv", venvDirectory.toString(), "--without-pip");
+            runVenvBin(venvDirectory, "graalpy", "-I", "-m", "ensurepip");
+        }
+
+        deleteUnwantedPackages(venvDirectory, installedPackages, packages);
+        installWantedPackages(venvDirectory, installedPackages, packages);
+
+        try {
+            Files.write(venvContents, List.of(graalPyVersion), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            Files.write(venvContents, packages, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new GradleScriptException(String.format("failed to write tag file %s", venvContents), e);
+        }
+    }
+
+    private void listGraalPyResources() {
+        Path vfs = getHomeDirectory().getParent();
+        if (Files.exists(vfs)) {
+            try {
+                VFSUtils.generateVFSFilesList(vfs);
+            } catch (IOException e) {
+                throw new GradleScriptException(String.format("Failed to generate files list in '%s'", vfs), e);
+            }
+        }
+    }
+
+    private Set<String> calculateLauncherClasspath() {
+        if (launcherClassPath == null) {
+            var addedPluginDependency = getProject().getConfigurations().getByName("runtimeClasspath").getAllDependencies().stream().filter(d -> d.getGroup().equals(GRAALPY_GROUP_ID) && d.getName().equals("python-launcher") && d.getVersion().equals(getGraalPyVersion(getProject()))).findFirst().orElseThrow();
+            launcherClassPath = getProject().getConfigurations().getByName("runtimeClasspath").files(addedPluginDependency).stream().map(File::toString).collect(Collectors.toSet());
+            launcherClassPath.addAll(getProject().getConfigurations().getByName("runtimeClasspath").files(getGraalPyDependency(getProject())).stream().map(File::toString).collect(Collectors.toSet()));
+        }
+        return launcherClassPath;
+    }
+
+    private boolean pythonHomeChanged(List<String> includes, List<String> excludes, List<String> lines)  {
+        Set<String> prevIncludes = new HashSet<>();
+        Set<String> prevExcludes = new HashSet<>();
+        for (int i = 1; i < lines.size(); i++) {
+            String l = lines.get(i);
+            if (l.startsWith(INCLUDE_PREFIX)) {
+                prevIncludes.add(l.substring(INCLUDE_PREFIX.length()));
+            } else if (l.startsWith(EXCLUDE_PREFIX)) {
+                prevExcludes.add(l.substring(EXCLUDE_PREFIX.length()));
+            }
+        }
+        boolean includeDidNotChange = prevIncludes.size() == includes.size() &&  prevIncludes.containsAll(includes);
+        boolean excludeDidNotChange = prevExcludes.size() == excludes.size() &&  prevExcludes.containsAll(excludes);
+        return !(includeDidNotChange && excludeDidNotChange);
+    }
+
+    private void generateLaunchers() {
+        getLogger().lifecycle("Generating GraalPy launchers");
+        var launcher = getLauncherPath();
+        if (!Files.exists(launcher)) {
+            var java = Paths.get(System.getProperty("java.home"), "bin", "java");
+            var classpath = calculateLauncherClasspath();
+            if (!IS_WINDOWS) {
+                var script = String.format("""
+                                #!/usr/bin/env bash
+                                %s -classpath %s %s --python.Executable="$0" "$@"
+                                """,
+                        java,
+                        String.join(File.pathSeparator, classpath),
+                        GRAALPY_MAIN_CLASS);
+                try {
+                    Files.createDirectories(launcher.getParent());
+                    Files.writeString(launcher, script);
+                    var perms = Files.getPosixFilePermissions(launcher);
+                    perms.addAll(List.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_EXECUTE, PosixFilePermission.OTHERS_EXECUTE));
+                    Files.setPosixFilePermissions(launcher, perms);
+                } catch (IOException e) {
+                    throw new GradleException(String.format("failed to create launcher %s", launcher), e);
+                }
+            } else {
+                // on windows, generate a venv launcher that executes our mvn target
+                var script = String.format("""
+                                import os, shutil, struct, venv
+                                from pathlib import Path
+                                vl = os.path.join(venv.__path__[0], 'scripts', 'nt', 'graalpy.exe')
+                                tl = os.path.join(r'%s')
+                                os.makedirs(Path(tl).parent.absolute(), exist_ok=True)
+                                shutil.copy(vl, tl)
+                                cmd = r'%s -classpath "%s" %s'
+                                pyvenvcfg = os.path.join(os.path.dirname(tl), "pyvenv.cfg")
+                                with open(pyvenvcfg, 'w', encoding='utf-8') as f:
+                                    f.write('venvlauncher_command = ')
+                                    f.write(cmd)
+                                """,
+                        launcher,
+                        java,
+                        String.join(File.pathSeparator, classpath),
+                        GRAALPY_MAIN_CLASS);
+                File tmp;
+                try {
+                    tmp = File.createTempFile("create_launcher", ".py");
+                } catch (IOException e) {
+                    throw new GradleScriptException("failed to create tmp launcher", e);
+                }
+                tmp.deleteOnExit();
+                try (var wr = new FileWriter(tmp)) {
+                    wr.write(script);
+                } catch (IOException e) {
+                    throw new GradleScriptException(String.format("failed to write tmp launcher %s", tmp), e);
+                }
+                runGraalPy(tmp.getAbsolutePath());
+            }
+        }
+    }
+
+    private void runGraalPy(String... args) {
+        var classpath = calculateLauncherClasspath();
+        try {
+            GraalPyRunner.run(classpath, GradleLogger.of(getLogger()), args);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleScriptException("failed to run Graalpy launcher", e);
+        }
+    }
+
+    private Path getLauncherPath() {
+        return Paths.get(getProject().getBuildDir().getAbsolutePath(), LAUNCHER);
+    }
+
+
+    private static void write(Path tag, Collection<String> list, String prefix) throws IOException {
+        if (list != null && !list.isEmpty()) {
+            Files.write(tag, list.stream().map(l -> prefix + l).collect(Collectors.toList()), StandardOpenOption.APPEND);
+        }
+    }
+
+    private Path getHomeDirectory() {
+        return getResourceDirectory(VFS_HOME);
+    }
+
+    private Path getVenvDirectory() {
+        return getResourceDirectory(VFS_VENV);
+    }
+
+    private Path getResourceDirectory(String type) {
+        return Path.of(getOutput().get().getAsFile().toURI()).resolve(getIncludeVfsRoot().getOrElse(true) ? VFS_ROOT : "").resolve(type);
+    }
+
+    private static void delete(Path homeDirectory) {
+        try {
+            try (var s = Files.walk(homeDirectory)) {
+                s.sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+            }
+        } catch (IOException e) {
+            throw new GradleScriptException(String.format("failed to delete %s", homeDirectory), e);
+        }
+    }
+
+    private static void trim(List<String> l) {
+        Iterator<String> it = l.iterator();
+        while (it.hasNext()) {
+            String p = it.next();
+            if (p == null || p.trim().isEmpty()) {
+                it.remove();
+            }
+        }
+    }
+
+    private void installWantedPackages(Path venvDirectory, List<String> installedPackages, List<String> wantedPackages) {
+        var pkgsToInstall = new HashSet<>(wantedPackages);
+        installedPackages.forEach(pkgsToInstall::remove);
+        if (pkgsToInstall.isEmpty()) {
+            return;
+        }
+        getLogger().lifecycle("Installing packages {}", pkgsToInstall);
+        runPip(venvDirectory, "install", pkgsToInstall.toArray(new String[pkgsToInstall.size()]));
+    }
+
+    private void deleteUnwantedPackages(Path venvDirectory, List<String> installedPackages, List<String> wantedPackages) {
+        List<String> args = new ArrayList<>(installedPackages);
+        args.removeAll(wantedPackages);
+        if (args.isEmpty()) {
+            return;
+        }
+        args.add(0, "-y");
+        getLogger().lifecycle("Removing packages {}", args);
+        runPip(venvDirectory, "uninstall", args.toArray(new String[args.size()]));
+    }
+
+
+    private void runLauncher(String launcherPath, String... args) {
+        try {
+            GraalPyRunner.runLauncher(launcherPath, GradleLogger.of(getLogger()), args);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleScriptException(String.format("failed to execute launcher command %s", List.of(args)), e);
+        }
+    }
+
+    private void runPip(Path venvDirectory, String command, String... args) {
+        try {
+            GraalPyRunner.runPip(venvDirectory, command, GradleLogger.of(getLogger()), args);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleScriptException(String.format("failed to execute pip", args), e);
+        }
+    }
+
+    private void runVenvBin(Path venvDirectory, String bin, String... args) {
+        try {
+            GraalPyRunner.runVenvBin(venvDirectory, bin, GradleLogger.of(getLogger()), args);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleScriptException(String.format("failed to execute venv", args), e);
+        }
+    }
+}

--- a/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/InstallPackagesTask.java
+++ b/graalpython/graalpy-gradle-plugin/src/main/java/org/graalvm/python/tasks/InstallPackagesTask.java
@@ -1,3 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.graalvm.python.tasks;
 
 import org.graalvm.python.GradleLogger;

--- a/graalpython/graalpy-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.graalvm.python.properties
+++ b/graalpython/graalpy-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.graalvm.python.properties
@@ -1,0 +1,3 @@
+implementation-class=org.graalvm.python.GraalPyGradlePlugin
+version=24.2.0
+id=org.graalvm.python

--- a/mx.graalpython/suite.py
+++ b/mx.graalpython/suite.py
@@ -1465,6 +1465,19 @@ suite = {
             },
         },
 
+        "graalpy-gradle-plugin": {
+            "class": "MavenProject",
+            "subDir": "graalpython",
+            "noMavenJavadoc": True,
+            "dependencies": [
+                "GRAALPYTHON-LAUNCHER",
+                "GRAALPYTHON_EMBEDDING_TOOLS",
+            ],
+            "maven": {
+                "tag": ["default", "public"],
+            },
+        },
+
         "graalpy-micronaut-embedding": {
             "class": "MavenProject",
             "subDir": "graalpython",


### PR DESCRIPTION
The plugin requires the `java`-Plugin. If it is not loaded, the plugin will apply it.

It adds to task in the `graalpy` section:
```
graalpy {
  generateManifest
  installPackages
}
```

It may be configured in the the `build.gradle` with the following settings:
```groovy
graalPy {
    packages = ["tqdm==4.66.4", "ujson"] // default: []
    includeVfsRootDir = true // default: true. If true, the venv and home will be put into: org.graalvm.python.vfs
    pythonHome {
        includes = ["someRegex"] // default: [".*"]
        excludes = ["someRegex"] // default: []
    }
    pythonResourcesDirectory = file "path/to/some/dir" // default: $buildDir/python-generated
   // if no value is provided for the directory, it will also be added to the classpath and added to the jar
}
```