### PR TITLE
fix: ensure minimum is java 17

### DIFF
--- a/graalpython/graalpy-jbang/examples/hello.java
+++ b/graalpython/graalpy-jbang/examples/hello.java
@@ -39,7 +39,7 @@
  * SOFTWARE.
  */
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-
+//JAVA 17+
 //DEPS org.graalvm.python:python-language:${env.GRAALPY_VERSION:24.0.0}
 //DEPS org.graalvm.python:python-resources:${env.GRAALPY_VERSION:24.0.0}
 //DEPS org.graalvm.python:python-launcher:${env.GRAALPY_VERSION:24.0.0}

--- a/graalpython/graalpy-jbang/templates/graalpy-template.java.qute
+++ b/graalpython/graalpy-jbang/templates/graalpy-template.java.qute
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 17+
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}

--- a/graalpython/graalpy-jbang/templates/graalpy-template_local_repo.java.qute
+++ b/graalpython/graalpy-jbang/templates/graalpy-template_local_repo.java.qute
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 17+
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}


### PR DESCRIPTION
currently if you run `jbang hello@oracle/graalpython` with java less than java 17 it fails with error.

this fix uses `//JAVA 17+` to indicate that it should run with at least java 17 or higher.