### PR TITLE
fix pymongo.patch for more pymongo versions

### DIFF
--- a/graalpython/lib-graalpython/patches/metadata.toml
+++ b/graalpython/lib-graalpython/patches/metadata.toml
@@ -478,7 +478,13 @@ patch = 'pygame-2.patch'
 license = 'LGPL-2.0-or-later'
 
 [[pymongo.rules]]
+version = "< 4.8.0"
 patch = 'pymongo.patch'
+license = 'Apache-2.0'
+
+[[pymongo.rules]]
+version = ">= 4.8.0"
+patch = 'pymongo-4.8.0.patch'
 license = 'Apache-2.0'
 
 [[pyOpenSSL.rules]]

--- a/graalpython/lib-graalpython/patches/pymongo-4.8.0.patch
+++ b/graalpython/lib-graalpython/patches/pymongo-4.8.0.patch
@@ -1,7 +1,7 @@
-diff --git a/setup.py b/setup.py
+diff --git a/_setup.py b/_setup.py
 index a711e24..84d3aea 100644
---- a/setup.py
-+++ b/setup.py
+--- a/_setup.py
++++ b/_setup.py
 @@ -128,1 +128,1 @@
 -elif sys.platform.startswith("java") or sys.platform == "cli" or "PyPy" in sys.version:
 +elif sys.platform.startswith("java") or sys.platform == "cli" or "PyPy" in sys.version or sys.implementation.name == 'graalpy':


### PR DESCRIPTION
(tested on 4.3.3, 4.10.1)

reason:
1. the original patch compares too many lines, thus quite some pymongo versions actually failed the patch examination, thus we reduce it into a one liner. well according to history, this line nearlly always unchanged, and seems no reason for anyone to add another same line in anyway.
2. since pymongo 4.8 they move things in setup.py to _setup.py, thus the patch shall suite too.