### PR TITLE
[GH-676] Fix wrong type name in `__repr__` TypeError message

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/lib/PyObjectReprAsObjectNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/lib/PyObjectReprAsObjectNode.java
@@ -108,7 +108,7 @@ public abstract class PyObjectReprAsObjectNode extends PNodeWithContext {
         if (checkNode.execute(inliningTarget, result)) {
             return result;
         } else {
-            throw raiseTypeError(inliningTarget, obj, raiseNode);
+            throw raiseTypeError(inliningTarget, result, raiseNode);
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #676.

When `__repr__` returns a non-string value, the `TypeError` message incorrectly reports the type of the object being repr'd instead of the return value's type, diverging from CPython.

#### AS-IS
```
TypeError: __repr__ returned non-string (type A)
```
(type of the object)

#### TO-BE
```
TypeError: __repr__ returned non-string (type bool)
```
(type of the return value, matching CPython)

## Change

Pass `result` (the `__repr__` return value) instead of `obj` (the object being repr'd) to `raiseTypeError` in `PyObjectReprAsObjectNode.java`. The equivalent `__str__` path in `PyObjectStrAsObjectNode.java` already does this correctly.