### PR TITLE
Fix exception type for negative `__length_hint__` return value

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/iterator/IteratorNodes.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/iterator/IteratorNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/iterator/IteratorNodes.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/iterator/IteratorNodes.java
@@ -42,6 +42,7 @@ package com.oracle.graal.python.builtins.objects.iterator;
 
 import static com.oracle.graal.python.builtins.PythonBuiltinClassType.PIterator;
 import static com.oracle.graal.python.builtins.PythonBuiltinClassType.TypeError;
+import static com.oracle.graal.python.builtins.PythonBuiltinClassType.ValueError;
 import static com.oracle.graal.python.nodes.SpecialMethodNames.T___LENGTH_HINT__;
 import static com.oracle.graal.python.util.PythonUtils.TS_ENCODING;
 
@@ -202,7 +203,7 @@ public abstract class IteratorNodes {
                     if (indexCheckNode.execute(inliningTarget, len)) {
                         int intLen = asSizeNode.executeExact(frame, inliningTarget, len);
                         if (intLen < 0) {
-                            throw raiseNode.raise(inliningTarget, TypeError, ErrorMessages.LENGTH_HINT_SHOULD_RETURN_MT_ZERO);
+                            throw raiseNode.raise(inliningTarget, ValueError, ErrorMessages.LENGTH_HINT_SHOULD_RETURN_MT_ZERO);
                         }
                         return intLen;
                     } else {


### PR DESCRIPTION
## Description

Fixes #757

When `__length_hint__()` returns a negative integer, GraalPy raises `TypeError` instead of `ValueError`. CPython's `PyObject_LengthHint` (`Objects/abstract.c:141-144`) raises `ValueError` for this case.

#### AS-IS
```
TypeError: __length_hint__() should return >= 0
```

#### TO-BE
```
ValueError: __length_hint__() should return >= 0
```
(matching CPython)

## Changes

- Raise `ValueError` instead of `TypeError` for negative `__length_hint__` return value in `IteratorNodes.GetLength.length`, matching CPython's [`PyObject_LengthHint`](https://github.com/python/cpython/blob/v3.12.13/Objects/abstract.c#L141-L144). The adjacent non-integer branch continues to raise `TypeError` as before.