### PR TITLE
Raise IndexError for deque indices below -len. Fixes oracle/graalpython#923

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/tests/test_deque.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_deque.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # The Universal Permissive License (UPL), Version 1.0
@@ -393,6 +393,17 @@ class TestBasic(unittest.TestCase):
             del d[j]
             self.assertTrue(val not in d)
         self.assertEqual(len(d), 0)
+
+    def test_negative_index_out_of_range(self):
+        # GH-923: an index < -len must raise IndexError, not wrap around twice
+        d = deque([10, 20, 30, 40, 50])
+        i = -len(d) - 1
+        with self.assertRaises(IndexError):
+            d[i]
+        with self.assertRaises(IndexError):
+            d[i] = 0
+        with self.assertRaises(IndexError):
+            del d[i]
 
     def test_reverse(self):
         n = 500         # O(n**2) test, don't make this too big

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/deque/DequeBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/deque/DequeBuiltins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -76,7 +76,6 @@ import com.oracle.graal.python.builtins.PythonBuiltinClassType;
 import com.oracle.graal.python.builtins.PythonBuiltins;
 import com.oracle.graal.python.builtins.objects.PNone;
 import com.oracle.graal.python.builtins.objects.PNotImplemented;
-import com.oracle.graal.python.builtins.objects.common.IndexNodes.NormalizeIndexCustomMessageNode;
 import com.oracle.graal.python.builtins.objects.deque.DequeBuiltinsClinicProviders.DequeInsertNodeClinicProviderGen;
 import com.oracle.graal.python.builtins.objects.deque.DequeBuiltinsClinicProviders.DequeRotateNodeClinicProviderGen;
 import com.oracle.graal.python.builtins.objects.function.PKeyword;
@@ -824,9 +823,12 @@ public final class DequeBuiltins extends PythonBuiltins {
         @Specialization
         @TruffleBoundary
         Object doGeneric(PDeque self, int idx,
-                        @Cached NormalizeIndexCustomMessageNode normalizeIndexNode) {
-            int normIdx = normalizeIndexNode.execute(idx, self.getSize(), ErrorMessages.DEQUE_INDEX_OUT_OF_RANGE);
-            return doGetItem(self, normIdx);
+                        @Bind Node inliningTarget,
+                        @Cached PRaiseNode raiseNode) {
+            if (idx < 0 || idx >= self.getSize()) {
+                throw raiseNode.raise(inliningTarget, IndexError, ErrorMessages.DEQUE_INDEX_OUT_OF_RANGE);
+            }
+            return doGetItem(self, idx);
         }
 
         @TruffleBoundary
@@ -846,9 +848,12 @@ public final class DequeBuiltins extends PythonBuiltins {
 
         @Specialization
         static void setOrDel(PDeque self, int idx, Object value,
-                        @Cached NormalizeIndexCustomMessageNode normalizeIndexNode) {
-            int normIdx = normalizeIndexNode.execute(idx, self.getSize(), ErrorMessages.DEQUE_INDEX_OUT_OF_RANGE);
-            self.setItem(normIdx, value != PNone.NO_VALUE ? value : null);
+                        @Bind Node inliningTarget,
+                        @Cached PRaiseNode raiseNode) {
+            if (idx < 0 || idx >= self.getSize()) {
+                throw raiseNode.raise(inliningTarget, IndexError, ErrorMessages.DEQUE_INDEX_OUT_OF_RANGE);
+            }
+            self.setItem(idx, value != PNone.NO_VALUE ? value : null);
         }
     }
 

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/type/slots/TpSlotSizeArgFun.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/type/slots/TpSlotSizeArgFun.java
@@ -174,7 +174,7 @@ public class TpSlotSizeArgFun {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     fixNegativeIndex = insert(FixNegativeIndex.create());
                 }
-                size = fixNegativeIndex.execute(frame, size, index);
+                size = fixNegativeIndex.execute(frame, size, self);
             }
             return slotNode.execute(frame, self, size);
         }
@@ -210,17 +210,17 @@ public class TpSlotSizeArgFun {
 
     @GenerateInline(false) // lazy
     public abstract static class FixNegativeIndex extends Node {
-        public abstract int execute(VirtualFrame frame, int indexAsSize, Object indexObj);
+        public abstract int execute(VirtualFrame frame, int indexAsSize, Object self);
 
         @Specialization
-        static int doIt(VirtualFrame frame, int indexAsSize, Object indexObj,
+        static int doIt(VirtualFrame frame, int indexAsSize, Object self,
                         @Bind Node inliningTarget,
-                        @Cached GetObjectSlotsNode getIndexSlots,
+                        @Cached GetObjectSlotsNode getSelfSlots,
                         @Cached CallSlotLenNode callSlotLen) {
             assert indexAsSize < 0;
-            TpSlots indexSlots = getIndexSlots.execute(inliningTarget, indexObj);
-            if (indexSlots.sq_length() != null) {
-                int len = callSlotLen.execute(frame, inliningTarget, indexSlots.sq_length(), indexObj);
+            TpSlots selfSlots = getSelfSlots.execute(inliningTarget, self);
+            if (selfSlots.sq_length() != null) {
+                int len = callSlotLen.execute(frame, inliningTarget, selfSlots.sq_length(), self);
                 return indexAsSize + len;
             }
             return indexAsSize;

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/type/slots/TpSlotSqAssItem.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/type/slots/TpSlotSqAssItem.java
@@ -174,7 +174,7 @@ public final class TpSlotSqAssItem {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     fixNegativeIndex = insert(FixNegativeIndex.create());
                 }
-                size = fixNegativeIndex.execute(frame, size, index);
+                size = fixNegativeIndex.execute(frame, size, self);
             }
             slotNode.executeIntKey(frame, self, size, value);
             return PNone.NONE;
@@ -209,7 +209,7 @@ public final class TpSlotSqAssItem {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     fixNegativeIndex = insert(FixNegativeIndex.create());
                 }
-                size = fixNegativeIndex.execute(frame, size, index);
+                size = fixNegativeIndex.execute(frame, size, self);
             }
             slotNode.executeIntKey(frame, self, size, PNone.NO_VALUE);
             return PNone.NONE;


### PR DESCRIPTION
## Summary

Subscripting a `deque` with an index less than `-len(d)` wrapped around a second time instead of raising `IndexError`. On a length-5 deque, `d[-6]` returned `d[4]` rather than raising, and `IndexError` only appeared once the index went below `-2*len`. This affected reads, assignments, and deletions via the subscript operator. Fixes oracle/graalpython#923.

```python
from collections import deque
d = deque([10, 20, 30, 40, 50])
d[-6]   # CPython: IndexError;  GraalPy (before): 50
```

## Root cause

The negative index was normalized **twice**:

1. The subscript machinery (`PyObjectGetItem` / `PyObjectSetItem` / `PyObjectDelItem` → `IndexForSqSlot`) already adds `len(self)` to a negative index, mirroring CPython's `PySequence_GetItem`.
2. The deque slots `DequeGetItemNode` (`sq_item`) and `DequeSetItemNode` (`sq_ass_item`) then added `len(self)` **again** via `NormalizeIndexCustomMessageNode`.

So `d[-6]` on a length-5 deque became `-6 + 5 = -1` (step 1) and then `-1 + 5 = 4` (step 2), reading a valid slot instead of raising.

This is deque-specific: every other builtin sequence (`list`, `tuple`, `str`, `bytes`, `array`, …) also defines `mp_subscript`, so its subscripting goes through the mapping slot (normalized once). `deque` is the only builtin sequence that defines `sq_item`/`sq_ass_item` **without** the `mp_*` counterparts, so its subscripting goes through the sequence-slot path that double-normalized.

## Fix

Aligns deque with CPython's division of labor (the caller normalizes; the slot only bounds-checks):

- `DequeGetItemNode` / `DequeSetItemNode` now only perform a bounds check and raise `IndexError`, matching `_collectionsmodule.c:deque_item` / `deque_ass_item` (and how `list`'s `sq_item` slot, `SequenceStorageSqItemNode`, already behaves).
- The shared `sq_*` wrappers `WrapSqItemBuiltinNode`, `WrapSqSetItemBuiltinNode`, and `WrapSqDelItemBuiltinNode` now pass `self` (not the index object) to `FixNegativeIndex`, so the adjustment uses `len(self)`, matching CPython's `typeobject.c:getindex`. Previously they passed the index object, making `FixNegativeIndex` compute `len(index)` — a no-op for integer indices. That latent bug was masked while the slot still normalized; once the slot stops normalizing, the wrapper must do the single normalization so the `__getitem__`/`__setitem__`/`__delitem__` method path stays correct.

## Testing

- New regression test `test_negative_index_out_of_range` in `test_deque.py` (covers `d[i]`, `d[i] = x`, `del d[i]` for `i < -len`).