### PR TITLE
Implement shm_open for _posixshmem. Fixes oracle/graalpython#502

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/tests/test_multiprocessing.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_multiprocessing.py
@@ -58,3 +58,36 @@ class MultiprocessingTest(unittest.TestCase):
         multiprocessing.Value('d', 0.0)
         arr = multiprocessing.Array('i', range(10))
         self.assertEqual(arr[1], 1)
+
+
+@unittest.skipIf(POSIX_BACKEND_IS_JAVA, "shared memory doesn't work on emulated backend")
+@unittest.skipUnless(sys.platform != 'win32', "POSIX shared memory")
+class SharedMemoryTest(unittest.TestCase):
+    def test_create_write_read_unlink(self):
+        from multiprocessing.shared_memory import SharedMemory
+        shm = SharedMemory(create=True, size=16)
+        try:
+            shm.buf[:5] = b"hello"
+            other = SharedMemory(shm.name)
+            try:
+                self.assertEqual(bytes(other.buf[:5]), b"hello")
+            finally:
+                other.close()
+        finally:
+            shm.close()
+            shm.unlink()
+
+    def test_open_missing_raises(self):
+        from multiprocessing.shared_memory import SharedMemory
+        with self.assertRaises(FileNotFoundError):
+            SharedMemory("graalpy_nonexistent_shm")
+
+    def test_create_existing_raises(self):
+        from multiprocessing.shared_memory import SharedMemory
+        shm = SharedMemory(create=True, size=16)
+        try:
+            with self.assertRaises(FileExistsError):
+                SharedMemory(shm.name, create=True, size=16)
+        finally:
+            shm.close()
+            shm.unlink()

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/modules/PosixShMemModuleBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/modules/PosixShMemModuleBuiltins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -42,15 +42,30 @@ package com.oracle.graal.python.builtins.modules;
 
 import java.util.List;
 
+import com.oracle.graal.python.annotations.ArgumentClinic;
+import com.oracle.graal.python.annotations.ArgumentClinic.ClinicConversion;
 import com.oracle.graal.python.annotations.Builtin;
 import com.oracle.graal.python.builtins.CoreFunctions;
 import com.oracle.graal.python.builtins.PythonBuiltins;
+import com.oracle.graal.python.builtins.modules.PosixModuleBuiltins.PathConversionNode;
+import com.oracle.graal.python.builtins.modules.PosixModuleBuiltins.PosixPath;
 import com.oracle.graal.python.builtins.objects.PNone;
+import com.oracle.graal.python.nodes.PConstructAndRaiseNode;
 import com.oracle.graal.python.nodes.function.PythonBuiltinBaseNode;
-import com.oracle.graal.python.nodes.function.builtins.PythonUnaryBuiltinNode;
+import com.oracle.graal.python.nodes.function.builtins.PythonClinicBuiltinNode;
+import com.oracle.graal.python.nodes.function.builtins.PythonUnaryClinicBuiltinNode;
+import com.oracle.graal.python.nodes.function.builtins.clinic.ArgumentClinicProvider;
+import com.oracle.graal.python.runtime.PosixSupportLibrary;
+import com.oracle.graal.python.runtime.PosixSupportLibrary.PosixException;
+import com.oracle.graal.python.runtime.PythonContext;
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
 
 @CoreFunctions(defineModule = "_posixshmem")
 public final class PosixShMemModuleBuiltins extends PythonBuiltins {
@@ -60,12 +75,53 @@ public final class PosixShMemModuleBuiltins extends PythonBuiltins {
         return PosixShMemModuleBuiltinsFactory.getFactories();
     }
 
-    @Builtin(name = "shm_unlink", minNumOfPositionalArgs = 1)
+    @Builtin(name = "shm_open", minNumOfPositionalArgs = 2, parameterNames = {"path", "flags", "mode"})
+    @ArgumentClinic(name = "path", conversionClass = PathConversionNode.class, args = {"false", "false"})
+    @ArgumentClinic(name = "flags", conversion = ClinicConversion.Int)
+    @ArgumentClinic(name = "mode", conversion = ClinicConversion.Int, defaultValue = "0777")
     @GenerateNodeFactory
-    public abstract static class LocaleConvNode extends PythonUnaryBuiltinNode {
-        @SuppressWarnings("unused")
+    public abstract static class ShmOpenNode extends PythonClinicBuiltinNode {
+
+        @Override
+        protected ArgumentClinicProvider getArgumentClinic() {
+            return PosixShMemModuleBuiltinsClinicProviders.ShmOpenNodeClinicProviderGen.INSTANCE;
+        }
+
         @Specialization
-        public Object doit(Object path) {
+        static int shmOpen(VirtualFrame frame, PosixPath path, int flags, int mode,
+                        @Bind Node inliningTarget,
+                        @Bind PythonContext context,
+                        @CachedLibrary("context.getPosixSupport()") PosixSupportLibrary posixLib,
+                        @Cached PConstructAndRaiseNode.Lazy constructAndRaiseNode) {
+            try {
+                return posixLib.shmOpen(context.getPosixSupport(), path.value, flags, mode);
+            } catch (PosixException e) {
+                throw constructAndRaiseNode.get(inliningTarget).raiseOSErrorFromPosixException(frame, e, path.originalObject);
+            }
+        }
+    }
+
+    @Builtin(name = "shm_unlink", minNumOfPositionalArgs = 1, parameterNames = {"path"})
+    @ArgumentClinic(name = "path", conversionClass = PathConversionNode.class, args = {"false", "false"})
+    @GenerateNodeFactory
+    public abstract static class ShmUnlinkNode extends PythonUnaryClinicBuiltinNode {
+
+        @Override
+        protected ArgumentClinicProvider getArgumentClinic() {
+            return PosixShMemModuleBuiltinsClinicProviders.ShmUnlinkNodeClinicProviderGen.INSTANCE;
+        }
+
+        @Specialization
+        static PNone shmUnlink(VirtualFrame frame, PosixPath path,
+                        @Bind Node inliningTarget,
+                        @Bind PythonContext context,
+                        @CachedLibrary("context.getPosixSupport()") PosixSupportLibrary posixLib,
+                        @Cached PConstructAndRaiseNode.Lazy constructAndRaiseNode) {
+            try {
+                posixLib.shmUnlink(context.getPosixSupport(), path.value);
+            } catch (PosixException e) {
+                throw constructAndRaiseNode.get(inliningTarget).raiseOSErrorFromPosixException(frame, e, path.originalObject);
+            }
             return PNone.NONE;
         }
     }

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/EmulatedPosixSupport.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/EmulatedPosixSupport.java
@@ -3068,13 +3068,13 @@ public final class EmulatedPosixSupport extends PosixResources {
     @ExportMessage
     @SuppressWarnings("unused")
     int shmOpen(Object name, int openFlags, int mode) throws PosixException {
-        throw posixException(OSErrorEnum.ENOENT);
+        throw createUnsupportedFeature("shm_open");
     }
 
     @ExportMessage
     @SuppressWarnings("unused")
     void shmUnlink(Object name) throws PosixException {
-        throw posixException(OSErrorEnum.ENOENT);
+        throw createUnsupportedFeature("shm_unlink");
     }
 
     @ExportMessage

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/EmulatedPosixSupport.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/EmulatedPosixSupport.java
@@ -3067,6 +3067,18 @@ public final class EmulatedPosixSupport extends PosixResources {
 
     @ExportMessage
     @SuppressWarnings("unused")
+    int shmOpen(Object name, int openFlags, int mode) throws PosixException {
+        throw posixException(OSErrorEnum.ENOENT);
+    }
+
+    @ExportMessage
+    @SuppressWarnings("unused")
+    void shmUnlink(Object name) throws PosixException {
+        throw posixException(OSErrorEnum.ENOENT);
+    }
+
+    @ExportMessage
+    @SuppressWarnings("unused")
     int semGetValue(long handle) throws PosixException {
         throw posixException(OSErrorEnum.EINVAL);
     }

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/LoggingPosixSupport.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/LoggingPosixSupport.java
@@ -1523,6 +1523,28 @@ public class LoggingPosixSupport extends PosixSupport {
     }
 
     @ExportMessage
+    final int shmOpen(Object name, int openFlags, int mode,
+                    @CachedLibrary("this.delegate") PosixSupportLibrary lib) throws PosixException {
+        logEnter("shmOpen", "%s %d %d", name, openFlags, mode);
+        try {
+            return logExit("shmOpen", "%d", lib.shmOpen(delegate, name, openFlags, mode));
+        } catch (PosixException e) {
+            throw logException("shmOpen", e);
+        }
+    }
+
+    @ExportMessage
+    final void shmUnlink(Object name,
+                    @CachedLibrary("this.delegate") PosixSupportLibrary lib) throws PosixException {
+        logEnter("shmUnlink", "%s", name);
+        try {
+            lib.shmUnlink(delegate, name);
+        } catch (PosixException e) {
+            throw logException("shmUnlink", e);
+        }
+    }
+
+    @ExportMessage
     final int semGetValue(long handle,
                     @CachedLibrary("this.delegate") PosixSupportLibrary lib) throws PosixException {
         logEnter("semGetValue", "0x%x", handle);

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/NativePosixSupport.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/NativePosixSupport.java
@@ -558,6 +558,12 @@ public final class NativePosixSupport extends PosixSupport {
         @DowncallSignature(returnType = SINT32, argumentTypes = {POINTER})
         abstract int call_sem_unlink(long name);
 
+        @DowncallSignature(returnType = SINT32, argumentTypes = {POINTER, SINT32, SINT32})
+        abstract int call_shm_open(long name, int openFlags, int mode);
+
+        @DowncallSignature(returnType = SINT32, argumentTypes = {POINTER})
+        abstract int call_shm_unlink(long name);
+
         @DowncallSignature(returnType = SINT32, argumentTypes = {POINTER, POINTER})
         abstract int call_sem_getvalue(long handle, long value);
 
@@ -2941,6 +2947,33 @@ public final class NativePosixSupport extends PosixSupport {
         long namePtr = pathToNativeCString(name);
         try {
             int res = posixNativeFunctionInvoker.call_sem_unlink(namePtr);
+            if (res < 0) {
+                throw getErrnoAndThrowPosixException();
+            }
+        } finally {
+            NativeMemory.free(namePtr);
+        }
+    }
+
+    @ExportMessage
+    int shmOpen(Object name, int openFlags, int mode) throws PosixException {
+        long namePtr = pathToNativeCString(name);
+        try {
+            int fd = posixNativeFunctionInvoker.call_shm_open(namePtr, openFlags, mode);
+            if (fd < 0) {
+                throw getErrnoAndThrowPosixException();
+            }
+            return fd;
+        } finally {
+            NativeMemory.free(namePtr);
+        }
+    }
+
+    @ExportMessage
+    void shmUnlink(Object name) throws PosixException {
+        long namePtr = pathToNativeCString(name);
+        try {
+            int res = posixNativeFunctionInvoker.call_shm_unlink(namePtr);
             if (res < 0) {
                 throw getErrnoAndThrowPosixException();
             }

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PosixSupportLibrary.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PosixSupportLibrary.java
@@ -390,6 +390,10 @@ public abstract class PosixSupportLibrary extends Library {
 
     public abstract void semUnlink(Object receiver, Object name) throws PosixException;
 
+    public abstract int shmOpen(Object receiver, Object name, int openFlags, int mode) throws PosixException;
+
+    public abstract void shmUnlink(Object receiver, Object name) throws PosixException;
+
     public abstract int semGetValue(Object receiver, long handle) throws PosixException;
 
     public abstract void semPost(Object receiver, long handle) throws PosixException;

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PreInitPosixSupport.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PreInitPosixSupport.java
@@ -1106,6 +1106,20 @@ public class PreInitPosixSupport extends PosixSupport {
     }
 
     @ExportMessage
+    final int shmOpen(Object name, int openFlags, int mode,
+                    @CachedLibrary("this.nativePosixSupport") PosixSupportLibrary lib) throws PosixException {
+        checkNotInPreInitialization();
+        return lib.shmOpen(nativePosixSupport, name, openFlags, mode);
+    }
+
+    @ExportMessage
+    final void shmUnlink(Object name,
+                    @CachedLibrary("this.nativePosixSupport") PosixSupportLibrary lib) throws PosixException {
+        checkNotInPreInitialization();
+        lib.shmUnlink(nativePosixSupport, name);
+    }
+
+    @ExportMessage
     final int semGetValue(long handle,
                     @CachedLibrary("this.nativePosixSupport") PosixSupportLibrary lib) throws PosixException {
         checkNotInPreInitialization();

--- a/graalpython/lib-python/3/multiprocessing/resource_tracker.py
+++ b/graalpython/lib-python/3/multiprocessing/resource_tracker.py
@@ -46,10 +46,9 @@ if os.name == 'posix':
         _CLEANUP_FUNCS.update({
             'semaphore': _multiprocessing.sem_unlink,
         })
-    # GraalPy change: comment out unit we implement _posixshmem properly
-    # _CLEANUP_FUNCS.update({
-    #     'shared_memory': _posixshmem.shm_unlink,
-    # })
+    _CLEANUP_FUNCS.update({
+        'shared_memory': _posixshmem.shm_unlink,
+    })
 
 
 class ReentrantCallError(RuntimeError):

--- a/graalpython/python-libposix/src/posix.c
+++ b/graalpython/python-libposix/src/posix.c
@@ -1095,6 +1095,14 @@ int32_t call_sem_close(sem_t* handle) {
     CAPTURE_ERRNO_AND_RETURN(-1, sem_close(handle));
 }
 
+int32_t call_shm_open(const char *name, int32_t openFlags, int32_t mode) {
+    CAPTURE_ERRNO_AND_RETURN(-1, shm_open(name, openFlags, mode));
+}
+
+int32_t call_shm_unlink(const char *name) {
+    CAPTURE_ERRNO_AND_RETURN(-1, shm_unlink(name));
+}
+
 int32_t call_sem_unlink(const char *name) {
     CAPTURE_ERRNO_AND_RETURN(-1, sem_unlink(name));
 }

--- a/mx.graalpython/suite.py
+++ b/mx.graalpython/suite.py
@@ -834,7 +834,7 @@ suite = {
                 },
                 "<others>": {
                     "<others>": {
-                        "ldlibs": ["-lutil"],
+                        "ldlibs": ["-lutil", "-lrt"],
                         "defaultBuild": True,
                         "multitarget": [
                             {"libc": ["glibc", "default"]},


### PR DESCRIPTION
### Summary
`_posixshmem` was only a skeleton (a no-op `shm_unlink`, no `shm_open`), so `multiprocessing.shared_memory.SharedMemory` failed with `AttributeError: module '_posixshmem' has no attribute 'shm_open'`. This implements real POSIX shared memory end to end, so shared-memory IPC works on GraalPy without user code changes.

Fixes graalvm/graalpython#502.

### Changes
- **Native helpers** (`python-libposix/src/posix.c`): add `call_shm_open` / `call_shm_unlink` with errno capture.
- **POSIX layer**: add `shmOpen` / `shmUnlink` to `PosixSupportLibrary` with implementations in all backends — `NativePosixSupport` (NFI downcalls), plus `Emulated`/`Logging`/`PreInit` wrappers.
- **Module builtins** (`PosixShMemModuleBuiltins`): implement `shm_open(path, flags, mode=0o777)` returning the fd and a real `shm_unlink(path)`, using the shared `PathConversionNode` and raising the correct `OSError` subclasses (`FileExistsError` / `FileNotFoundError`), mirroring `os.open`.
- **stdlib** (`multiprocessing/resource_tracker.py`): restore the upstream `shared_memory` → `_posixshmem.shm_unlink` cleanup registration (previously commented out).
- **Build** (`suite.py`): link `librt` (`-lrt`) on Linux so the symbols resolve on older glibc/musl.

### Notes
- Works on the native POSIX backend. On the emulated (pure-Java) backend, shared memory isn't available and raises `OSError`, consistent with the existing `sem_*` behavior.

### Testing
- New `SharedMemoryTest` in `test_multiprocessing.py` (create/write/read across handles, missing-segment and duplicate-create errors).