### PR TITLE
Fix `slice` repr leaking the internal storage representation.

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/tests/test_slice.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_slice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2025, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2026, Oracle and/or its affiliates.
 # Copyright (c) 2013, Regents of the University of California
 #
 # All rights reserved.
@@ -194,6 +194,25 @@ def test_correct_error():
         [1][:"42"]
     except TypeError as e:
         assert "slice indices must be integers" in str(e)
+
+
+def test_repr():
+    assert repr(slice(1, 2, 3)) == "slice(1, 2, 3)"
+    assert repr(slice(1, 2)) == "slice(1, 2, None)"
+    assert repr(slice(None)) == "slice(None, None, None)"
+    assert repr(slice(2**70)) == "slice(None, 1180591620717411303424, None)"
+    # each member is formatted with repr(), not with a debug representation
+    assert repr(slice(())) == "slice(None, (), None)"
+    assert repr(slice((1,))) == "slice(None, (1,), None)"
+    assert repr(slice([])) == "slice(None, [], None)"
+    assert repr(slice("")) == "slice(None, '', None)"
+    assert repr(slice(True, 2)) == "slice(True, 2, None)"
+
+    class Custom:
+        def __repr__(self):
+            return "<custom>"
+
+    assert repr(slice(Custom())) == "slice(None, <custom>, None)"
 
 
 def test_slice_eq():

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/slice/SliceBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/slice/SliceBuiltins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates.
  * Copyright (c) 2014, Regents of the University of California
  *
  * All rights reserved.
@@ -27,7 +27,6 @@ package com.oracle.graal.python.builtins.objects.slice;
 
 import static com.oracle.graal.python.nodes.SpecialMethodNames.J___REDUCE__;
 import static com.oracle.graal.python.runtime.exception.PythonErrorType.ValueError;
-import static com.oracle.graal.python.util.PythonUtils.toTruffleStringUncached;
 
 import java.util.List;
 
@@ -46,11 +45,13 @@ import com.oracle.graal.python.builtins.objects.slice.SliceNodes.CoerceToObjectS
 import com.oracle.graal.python.builtins.objects.slice.SliceNodes.ComputeIndices;
 import com.oracle.graal.python.builtins.objects.slice.SliceNodes.SliceCastToToBigInt;
 import com.oracle.graal.python.builtins.objects.slice.SliceNodes.SliceExactCastToInt;
+import com.oracle.graal.python.builtins.objects.str.StringUtils.SimpleTruffleStringFormatNode;
 import com.oracle.graal.python.builtins.objects.tuple.PTuple;
 import com.oracle.graal.python.builtins.objects.type.TpSlots;
 import com.oracle.graal.python.builtins.objects.type.slots.TpSlotHashFun.HashBuiltinNode;
 import com.oracle.graal.python.builtins.objects.type.slots.TpSlotRichCompare.RichCmpBuiltinNode;
 import com.oracle.graal.python.lib.PyObjectHashNode;
+import com.oracle.graal.python.lib.PyObjectReprAsTruffleStringNode;
 import com.oracle.graal.python.lib.PyObjectRichCompare;
 import com.oracle.graal.python.lib.PyObjectRichCompareBool;
 import com.oracle.graal.python.lib.PySliceNew;
@@ -65,7 +66,6 @@ import com.oracle.graal.python.nodes.object.BuiltinClassProfiles.IsBuiltinObject
 import com.oracle.graal.python.nodes.object.GetClassNode;
 import com.oracle.graal.python.runtime.exception.PException;
 import com.oracle.graal.python.runtime.object.PFactory;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
@@ -122,9 +122,14 @@ public final class SliceBuiltins extends PythonBuiltins {
     @GenerateNodeFactory
     abstract static class ReprNode extends PythonUnaryBuiltinNode {
         @Specialization
-        @TruffleBoundary
-        public static TruffleString repr(PSlice self) {
-            return toTruffleStringUncached(self.toString());
+        static TruffleString repr(VirtualFrame frame, PSlice self,
+                        @Bind Node inliningTarget,
+                        @Cached PyObjectReprAsTruffleStringNode reprNode,
+                        @Cached SimpleTruffleStringFormatNode simpleTruffleStringFormatNode) {
+            return simpleTruffleStringFormatNode.format("slice(%s, %s, %s)",
+                            reprNode.execute(frame, inliningTarget, self.getStart()),
+                            reprNode.execute(frame, inliningTarget, self.getStop()),
+                            reprNode.execute(frame, inliningTarget, self.getStep()));
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #1071

`slice.__repr__` formatted its three members with Java's `String.valueOf` instead of Python `repr()`, so any member whose debug `toString()` differs from its repr leaked the internal representation. `int` and `None` members were unaffected, which is why the common case looked correct.

#### AS-IS

`slice(())`, `slice([])`, `slice("")`, `slice(True, 2)`:

```
slice(None, tuple(EmptySequenceStorage[]), None)
slice(None, list(EmptySequenceStorage[]), None)
slice(None, , None)
slice(true, 2, None)
```

#### TO-BE

```
slice(None, (), None)
slice(None, [], None)
slice(None, '', None)
slice(True, 2, None)
```

(matching CPython)

## Changes

- Rewrite `SliceBuiltins.ReprNode` to apply `PyObjectReprAsTruffleStringNode` to `getStart()` / `getStop()` / `getStep()` and assemble the result with `SimpleTruffleStringFormatNode`, matching CPython's `slice(%R, %R, %R)`. `RangeBuiltins.ReprNode` already uses this shape for `range`, whose CPython repr formats its three members with `%R` in the same way. The specialization no longer needs `@TruffleBoundary`. Unlike `range`, whose members are always integers, a slice member can be an arbitrary object with a user-defined `__repr__`, so the repr node is called with the frame rather than `null`.
- Add `test_repr` to `test_slice.py`, covering the member types whose Java `toString()` diverges from their repr, and an object with a user-defined `__repr__` to pin that the member is formatted by Python `repr()`.

## Testing

`mx python-jvm` on linux-aarch64, then `mx graalpytest test_slice.py test_list.py test_tuple.py test_bytes.py test_memoryview.py test_range.py` — 224 tests, all pass. `repr()` of 15 slice forms (one-, two- and three-argument, with `int` / `None` / `bool` / `float` / `str` / `bytes` / `tuple` / `list` / `dict` members and an object with a user-defined `__repr__`) was compared against CPython 3.13.5 and matches on every one.