### PR TITLE
Fix `enumerate()` start handling for `None` and `__index__` arguments

### DIFF
--- a/graalpython/com.oracle.graal.python.test/src/tests/test_enumerate_start.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_enumerate_start.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+#
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+#
+# The above copyright notice and either this complete permission notice or at a
+# minimum a reference to the UPL must be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def assert_raises(err, fn, *args, **kwargs):
+    raised = False
+    try:
+        fn(*args, **kwargs)
+    except err:
+        raised = True
+    assert raised
+
+
+def test_explicit_none_start():
+    # GH-1074: start defaults to 0 only when the argument is omitted; an
+    # explicitly passed None goes through PyNumber_Index and raises
+    assert_raises(TypeError, enumerate, 'abc', None)
+    assert_raises(TypeError, enumerate, 'abc', start=None)
+
+
+def test_omitted_start_after_rejected_start():
+    # GH-1074: the specializations are shared, so rejecting a bad start must
+    # not break a later call that omits it
+    assert_raises(TypeError, enumerate, 'abc', 'x')
+    assert list(enumerate('abc')) == [(0, 'a'), (1, 'b'), (2, 'c')]

--- a/graalpython/com.oracle.graal.python.test/src/tests/test_enumerate_start.py
+++ b/graalpython/com.oracle.graal.python.test/src/tests/test_enumerate_start.py
@@ -59,3 +59,37 @@ def test_omitted_start_after_rejected_start():
     # not break a later call that omits it
     assert_raises(TypeError, enumerate, 'abc', 'x')
     assert list(enumerate('abc')) == [(0, 'a'), (1, 'b'), (2, 'c')]
+
+
+def test_bool_start():
+    # GH-1074: bool is an int subclass, so True is a start of 1
+    assert list(enumerate('abc', True)) == [(1, 'a'), (2, 'b'), (3, 'c')]
+    assert list(enumerate('abc', False)) == [(0, 'a'), (1, 'b'), (2, 'c')]
+
+
+def test_index_start():
+    # GH-1074: any object implementing __index__ is accepted as start
+    class Idx:
+        def __index__(self):
+            return 3
+
+    assert list(enumerate([9, 8, 7], Idx())) == [(3, 9), (4, 8), (5, 7)]
+
+
+def test_huge_index_start():
+    # GH-1074: an __index__ result too large for a Java long still works
+    class BigIdx:
+        def __index__(self):
+            return 2 ** 70
+
+    assert list(enumerate('a', BigIdx())) == [(1180591620717411303424, 'a')]
+
+
+def test_float_start_is_rejected():
+    assert_raises(TypeError, enumerate, 'abc', 1.0)
+
+
+def test_omitted_start_after_coerced_start():
+    # GH-1074: coercing a start must not break a later call that omits it
+    assert list(enumerate('abc', True)) == [(1, 'a'), (2, 'b'), (3, 'c')]
+    assert list(enumerate('abc')) == [(0, 'a'), (1, 'b'), (2, 'c')]

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/enumerate/EnumerateBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/enumerate/EnumerateBuiltins.java
@@ -29,7 +29,6 @@ import static com.oracle.graal.python.nodes.BuiltinNames.J_ENUMERATE;
 import static com.oracle.graal.python.nodes.PGuards.isInteger;
 import static com.oracle.graal.python.nodes.SpecialMethodNames.J___CLASS_GETITEM__;
 import static com.oracle.graal.python.nodes.SpecialMethodNames.J___REDUCE__;
-import static com.oracle.graal.python.runtime.exception.PythonErrorType.TypeError;
 
 import java.util.List;
 
@@ -49,14 +48,14 @@ import com.oracle.graal.python.builtins.objects.type.TpSlots.GetObjectSlotsNode;
 import com.oracle.graal.python.builtins.objects.type.TypeNodes;
 import com.oracle.graal.python.builtins.objects.type.slots.TpSlotIterNext.CallSlotTpIterNextNode;
 import com.oracle.graal.python.builtins.objects.type.slots.TpSlotIterNext.TpIterNextBuiltin;
+import com.oracle.graal.python.lib.PyNumberIndexNode;
 import com.oracle.graal.python.lib.PyObjectGetIter;
-import com.oracle.graal.python.nodes.ErrorMessages;
-import com.oracle.graal.python.nodes.PRaiseNode;
 import com.oracle.graal.python.nodes.function.PythonBuiltinBaseNode;
 import com.oracle.graal.python.nodes.function.PythonBuiltinNode;
 import com.oracle.graal.python.nodes.function.builtins.PythonBinaryBuiltinNode;
 import com.oracle.graal.python.nodes.function.builtins.PythonUnaryBuiltinNode;
 import com.oracle.graal.python.nodes.object.GetClassNode;
+import com.oracle.graal.python.nodes.util.CastToJavaLongExactNode;
 import com.oracle.graal.python.runtime.object.PFactory;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
@@ -66,6 +65,7 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.object.Shape;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 @CoreFunctions(extendClasses = PythonBuiltinClassType.PEnumerate)
@@ -84,7 +84,7 @@ public final class EnumerateBuiltins extends PythonBuiltins {
     public abstract static class EnumerateNode extends PythonBuiltinNode {
 
         @Specialization(guards = "isNoValue(keywordArg)")
-        static PEnumerate doNone(VirtualFrame frame, Object cls, Object iterable, @SuppressWarnings("unused") PNone keywordArg,
+        static PEnumerate doNoValue(VirtualFrame frame, Object cls, Object iterable, @SuppressWarnings("unused") PNone keywordArg,
                         @Bind Node inliningTarget,
                         @Shared("getIter") @Cached PyObjectGetIter getIter,
                         @Shared @Cached TypeNodes.GetInstanceShape getInstanceShape) {
@@ -119,11 +119,23 @@ public final class EnumerateBuiltins extends PythonBuiltins {
             return isInteger(idx) || idx instanceof PInt;
         }
 
+        // see cpython://Objects/enumobject.c#enum_new_impl
         // !isNoValue: specializations are shared, so an omitted start must not reach this branch
         @Specialization(guards = {"!isIntegerIndex(start)", "!isNoValue(start)"})
-        static void enumerate(@SuppressWarnings("unused") Object cls, @SuppressWarnings("unused") Object iterable, Object start,
-                        @Bind Node inliningTarget) {
-            throw PRaiseNode.raiseStatic(inliningTarget, TypeError, ErrorMessages.OBJ_CANNOT_BE_INTERPRETED_AS_INTEGER, start);
+        static PEnumerate doGeneric(VirtualFrame frame, Object cls, Object iterable, Object start,
+                        @Bind Node inliningTarget,
+                        @Shared("getIter") @Cached PyObjectGetIter getIter,
+                        @Shared @Cached TypeNodes.GetInstanceShape getInstanceShape,
+                        @Cached PyNumberIndexNode indexNode,
+                        @Cached CastToJavaLongExactNode cast,
+                        @Cached InlinedConditionProfile bigIntIndexProfile) {
+            Object index = indexNode.execute(frame, inliningTarget, start);
+            Object iterator = getIter.execute(frame, inliningTarget, iterable);
+            Shape shape = getInstanceShape.execute(cls);
+            if (bigIntIndexProfile.profile(inliningTarget, index instanceof PInt)) {
+                return PFactory.createEnumerate(cls, shape, iterator, (PInt) index);
+            }
+            return PFactory.createEnumerate(cls, shape, iterator, cast.execute(inliningTarget, index));
         }
     }
 

--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/enumerate/EnumerateBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/enumerate/EnumerateBuiltins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates.
  * Copyright (c) 2014, Regents of the University of California
  *
  * All rights reserved.
@@ -83,7 +83,7 @@ public final class EnumerateBuiltins extends PythonBuiltins {
     @GenerateNodeFactory
     public abstract static class EnumerateNode extends PythonBuiltinNode {
 
-        @Specialization
+        @Specialization(guards = "isNoValue(keywordArg)")
         static PEnumerate doNone(VirtualFrame frame, Object cls, Object iterable, @SuppressWarnings("unused") PNone keywordArg,
                         @Bind Node inliningTarget,
                         @Shared("getIter") @Cached PyObjectGetIter getIter,
@@ -119,7 +119,8 @@ public final class EnumerateBuiltins extends PythonBuiltins {
             return isInteger(idx) || idx instanceof PInt;
         }
 
-        @Specialization(guards = "!isIntegerIndex(start)")
+        // !isNoValue: specializations are shared, so an omitted start must not reach this branch
+        @Specialization(guards = {"!isIntegerIndex(start)", "!isNoValue(start)"})
         static void enumerate(@SuppressWarnings("unused") Object cls, @SuppressWarnings("unused") Object iterable, Object start,
                         @Bind Node inliningTarget) {
             throw PRaiseNode.raiseStatic(inliningTarget, TypeError, ErrorMessages.OBJ_CANNOT_BE_INTERPRETED_AS_INTEGER, start);


### PR DESCRIPTION
## Description

Fixes #1074

`enumerate()` mishandles its `start` argument in two independent ways. An explicit `start=None` is treated as if the argument had been omitted, so it silently means 0. And a `start` that is not already an `int` is rejected instead of being coerced, so `bool` and every object implementing `__index__` raise `TypeError`.

#### AS-IS

```
>>> enumerate("a", None)
<enumerate object at 0x2671a8f>
>>> list(enumerate("abc", True))
TypeError: 'bool' object cannot be interpreted as an integer
>>> list(enumerate([9, 8, 7], Three()))          # Three.__index__ returns 3
TypeError: 'Three' object cannot be interpreted as an integer
```

#### TO-BE

```
>>> enumerate("a", None)
TypeError: 'NoneType' object cannot be interpreted as an integer
>>> list(enumerate("abc", True))
[(1, 'a'), (2, 'b'), (3, 'c')]
>>> list(enumerate([9, 8, 7], Three()))
[(3, 9), (4, 8), (5, 7)]
```

(matching CPython)

The two halves ship together because the specializations are shared across call sites. An omitted `start` arrives as `PNone.NO_VALUE`, which is neither an integer index nor distinguishable from `PNone.NONE` by Java type, so guarding one specialization without the other moves the failure rather than removing it:

| call sequence in one process | before | default-branch guard only | both guards |
|---|---|---|---|
| `enumerate("a", None)` | enumerate object | TypeError | TypeError |
| then `enumerate("abc")` | `[(0, 'a'), (1, 'b'), (2, 'c')]` | TypeError — regression | `[(0, 'a'), (1, 'b'), (2, 'c')]` |

Each column is a build. The same branch is already reachable before this change by rejecting a bad `start` first — `enumerate("abc", "x")` in a `try`, then `enumerate("abc")`.

`range` already coerces its arguments through `PyNumberIndexNode` and separates an omitted argument with `isNoValue` guards, so this brings `enumerate` to the same shape.

## Changes

- Guard the specialization that defaults `start` to 0 with `isNoValue(keywordArg)` so it matches only an omitted argument, and rename it `doNoValue` to match.
- Replace the rejecting specialization with `doGeneric`, which coerces `start` through `PyNumberIndexNode` and `CastToJavaLongExactNode` before the iterator is acquired. Its failure path raises the same `ErrorMessages.OBJ_CANNOT_BE_INTERPRETED_AS_INTEGER` as before, so `None` and `float` keep their exact message.
- Add `!isNoValue(start)` to that specialization so an omitted argument can never reach it.
- Add `tests/test_enumerate_start.py` covering the explicit `None`, `bool`, an `__index__` implementer, one whose `__index__` overflows a `long`, a rejected `float`, and an omitted `start` following each of the rejected and coerced cases.

## Testing

`mx build` on linux-aarch64, then `mx graalpytest test_enumerate_start.py test_enumerate.py test_list.py test_tuple.py test_iterator.py` — 243 tests, all pass. CPython's own `test.test_enumerate` from `lib-python` passes as well (92 tests, 14 skipped).

Twelve call shapes were compared against CPython 3.12.10 on the built binary, including the sequences above that exercise the shared specialization state and an `__index__` that returns `2 ** 70`; all twelve agree. The table above was measured by building the unpatched tree, the one-guard variant, and the full change, and running the sequence against each.
